### PR TITLE
Remove M2 specifier and add macOS 15.x compatibility note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mac Mini M2 Server Setup
+# Mac Mini Server Setup
 
 Automated setup scripts for configuring an Apple Silicon Mac Mini as a home server with native macOS applications.
 
@@ -69,7 +69,9 @@ The setup process consists of two main phases:
 - Development Mac with:
   - 1Password CLI installed and authenticated
   - SSH keys generated (`~/.ssh/id_ed25519.pub`)
-  - Required 1Password vault items (see [AirDrop Prep Instructions](docs/airdrop-prep.md))
+  - Required 1Password vault items (see [AirDrop Prep Instructions](docs/setup/prep-airdrop.md))
+
+> **Compatibility Note**: This automation is designed and tested for **macOS 15.x on Apple Silicon**. It may work on earlier macOS versions or Intel-based Macs, but compatibility is not guaranteed and has not been tested.
 
 ### Setup Process
 

--- a/app-setup/plex-setup.sh
+++ b/app-setup/plex-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# plex-setup.sh - Native Plex Media Server setup script for Mac Mini M2 server
+# plex-setup.sh - Native Plex Media Server setup script for Mac Mini server
 #
 # This script sets up Plex Media Server natively on macOS with:
 # - SMB mount to NAS for media storage (retrieved from config.conf)

--- a/app-setup/rclone-setup.sh
+++ b/app-setup/rclone-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# rclone-setup.sh - Dropbox synchronization setup script for Mac Mini M2 server
+# rclone-setup.sh - Dropbox synchronization setup script for Mac Mini server
 #
 # This script sets up rclone-based Dropbox synchronization natively on macOS with:
 # - rclone configuration transfer from airdrop-prep.sh setup

--- a/docs/apps/plex-setup-README.md
+++ b/docs/apps/plex-setup-README.md
@@ -1,6 +1,6 @@
 # Plex Setup Script Documentation
 
-This document describes the `plex-setup.sh` script for Mac Mini M2 server Plex Media Server setup.
+This document describes the `plex-setup.sh` script for Mac Mini server Plex Media Server setup.
 
 ## Overview
 

--- a/docs/apps/rclone-setup-README.md
+++ b/docs/apps/rclone-setup-README.md
@@ -1,6 +1,6 @@
 # rclone Setup Script Documentation
 
-This document describes the `rclone-setup.sh` script for Mac Mini M2 server Dropbox synchronization.
+This document describes the `rclone-setup.sh` script for Mac Mini server Dropbox synchronization.
 
 ## Overview
 

--- a/docs/setup/first-boot.md
+++ b/docs/setup/first-boot.md
@@ -119,7 +119,7 @@ The script waits for you to complete Apple ID setup before continuing.
 The script automatically opens a second Terminal window showing live setup logs:
 
 ```plaintext
-[2025-08-04 10:30:15] ====== Starting Mac Mini M2 Server Setup ======
+[2025-08-04 10:30:15] ====== Starting Mac Mini Server Setup ======
 [2025-08-04 10:30:16] Running as user: admin
 [2025-08-04 10:30:16] ✅ TouchID sudo configuration
 [2025-08-04 10:30:18] ✅ SSH has been enabled successfully

--- a/docs/setup/firstboot-README.md
+++ b/docs/setup/firstboot-README.md
@@ -1,6 +1,6 @@
 # Server Setup Files
 
-This directory contains all the necessary files for setting up the Mac Mini M2 server.
+This directory contains all the necessary files for setting up the Mac Mini server.
 
 ## Contents
 

--- a/prep-airdrop.sh
+++ b/prep-airdrop.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 #
-# airdrop-prep.sh - Script to prepare a directory with necessary files for Mac Mini M2 server setup
+# airdrop-prep.sh - Script to prepare a directory with necessary files for Mac Mini server setup
 #
 # This script prepares a directory with all the necessary scripts and files
-# for setting up the Mac Mini M2 server. After running, AirDrop the entire directory
+# for setting up the Mac Mini server. After running, AirDrop the entire directory
 # to your new Mac Mini.
 #
 # Usage: ./airdrop-prep.sh [output_path] [script_path]
@@ -48,7 +48,7 @@ fi
 if [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]]; then
   echo "Usage: $(basename "$0") [output_path] [script_path]"
   echo ""
-  echo "Prepares setup files for Mac Mini M2 server deployment."
+  echo "Prepares setup files for Mac Mini server deployment."
   echo ""
   echo "Arguments:"
   echo "  output_path    Directory where setup files will be created (default: ~/${SERVER_NAME_LOWER:-server}-setup)"

--- a/scripts/server/first-boot.sh
+++ b/scripts/server/first-boot.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# first-boot.sh - Complete setup script for Mac Mini M2 server
+# first-boot.sh - Complete setup script for Mac Mini server
 #
 # This script performs the complete setup for the Mac Mini server after
 # the macOS setup wizard has been completed. It configures:
@@ -198,7 +198,7 @@ if [[ "${CURRENT_FINGERPRINT}" == "${DEV_MACHINE_FINGERPRINT}" ]]; then
   echo "Development fingerprint: ${DEV_MACHINE_FINGERPRINT}"
   echo "Current fingerprint: ${CURRENT_FINGERPRINT}"
   echo ""
-  echo "This script is only for target Mac Mini M2 server setup"
+  echo "This script is only for target Mac Mini server setup"
   exit 1
 fi
 
@@ -246,7 +246,7 @@ else
 fi
 
 # Print header
-section "Starting Mac Mini M2 '${SERVER_NAME}' Server Setup"
+section "Starting Mac Mini '${SERVER_NAME}' Server Setup"
 log "Running as user: ${ADMIN_USERNAME}"
 log -n "Date: "
 date


### PR DESCRIPTION
Changes:
- Remove "M2" references throughout documentation and scripts
- Add compatibility note to README.md specifying macOS 15.x on Apple Silicon
- Update script headers, documentation titles, and log messages
- Clarify that earlier macOS versions and Intel Macs are untested

The automation is designed for modern Apple Silicon Macs running current macOS versions, but may work on other configurations without guarantee.

Files updated:
- README.md: Added compatibility note, removed M2 from title
- Scripts: Updated headers and log messages (plex-setup.sh, rclone-setup.sh, first-boot.sh)
- Documentation: Updated titles and descriptions across all docs

🤖 Generated with [Claude Code](https://claude.ai/code)