### PR TITLE
Improve error collection output with line numbers and clean formatting

### DIFF
--- a/app-setup/plex-setup.sh
+++ b/app-setup/plex-setup.sh
@@ -145,19 +145,33 @@ set_section() {
 # Function to collect an error (with immediate display)
 collect_error() {
   local message="$1"
+  local line_number="${2:-${LINENO}}"
   local context="${CURRENT_SCRIPT_SECTION:-Unknown section}"
+  local script_name
+  script_name="$(basename "${BASH_SOURCE[1]:-${0}}")"
 
-  log "❌ ${message}"
-  COLLECTED_ERRORS+=("${context}: ${message}")
+  # Normalize message to single line (replace newlines with spaces)
+  local clean_message
+  clean_message="$(echo "${message}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+
+  log "❌ ${clean_message}"
+  COLLECTED_ERRORS+=("[${script_name}:${line_number}] ${context}: ${clean_message}")
 }
 
 # Function to collect a warning (with immediate display)
 collect_warning() {
   local message="$1"
+  local line_number="${2:-${LINENO}}"
   local context="${CURRENT_SCRIPT_SECTION:-Unknown section}"
+  local script_name
+  script_name="$(basename "${BASH_SOURCE[1]:-${0}}")"
 
-  log "⚠️ ${message}"
-  COLLECTED_WARNINGS+=("${context}: ${message}")
+  # Normalize message to single line (replace newlines with spaces)
+  local clean_message
+  clean_message="$(echo "${message}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+
+  log "⚠️ ${clean_message}"
+  COLLECTED_WARNINGS+=("[${script_name}:${line_number}] ${context}: ${clean_message}")
 }
 
 # Function to show collected errors and warnings at end
@@ -178,7 +192,7 @@ show_collected_issues() {
   if [[ ${error_count} -gt 0 ]]; then
     log "ERRORS:"
     for error in "${COLLECTED_ERRORS[@]}"; do
-      log "  ❌ ${error}"
+      log "  ${error}"
     done
     log ""
   fi
@@ -186,7 +200,7 @@ show_collected_issues() {
   if [[ ${warning_count} -gt 0 ]]; then
     log "WARNINGS:"
     for warning in "${COLLECTED_WARNINGS[@]}"; do
-      log "  ⚠️ ${warning}"
+      log "  ${warning}"
     done
     log ""
   fi

--- a/app-setup/rclone-setup.sh
+++ b/app-setup/rclone-setup.sh
@@ -114,19 +114,33 @@ set_section() {
 # Function to collect an error (with immediate display)
 collect_error() {
   local message="$1"
+  local line_number="${2:-${LINENO}}"
   local context="${CURRENT_SCRIPT_SECTION:-Unknown section}"
+  local script_name
+  script_name="$(basename "${BASH_SOURCE[1]:-${0}}")"
 
-  log "❌ ${message}"
-  COLLECTED_ERRORS+=("${context}: ${message}")
+  # Normalize message to single line (replace newlines with spaces)
+  local clean_message
+  clean_message="$(echo "${message}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+
+  log "❌ ${clean_message}"
+  COLLECTED_ERRORS+=("[${script_name}:${line_number}] ${context}: ${clean_message}")
 }
 
 # Function to collect a warning (with immediate display)
 collect_warning() {
   local message="$1"
+  local line_number="${2:-${LINENO}}"
   local context="${CURRENT_SCRIPT_SECTION:-Unknown section}"
+  local script_name
+  script_name="$(basename "${BASH_SOURCE[1]:-${0}}")"
 
-  log "⚠️ ${message}"
-  COLLECTED_WARNINGS+=("${context}: ${message}")
+  # Normalize message to single line (replace newlines with spaces)
+  local clean_message
+  clean_message="$(echo "${message}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+
+  log "⚠️ ${clean_message}"
+  COLLECTED_WARNINGS+=("[${script_name}:${line_number}] ${context}: ${clean_message}")
 }
 
 # Function to show collected errors and warnings at end
@@ -147,7 +161,7 @@ show_collected_issues() {
   if [[ ${error_count} -gt 0 ]]; then
     log "ERRORS:"
     for error in "${COLLECTED_ERRORS[@]}"; do
-      log "  ❌ ${error}"
+      log "  ${error}"
     done
     log ""
   fi
@@ -155,7 +169,7 @@ show_collected_issues() {
   if [[ ${warning_count} -gt 0 ]]; then
     log "WARNINGS:"
     for warning in "${COLLECTED_WARNINGS[@]}"; do
-      log "  ⚠️ ${warning}"
+      log "  ${warning}"
     done
     log ""
   fi

--- a/prep-airdrop.sh
+++ b/prep-airdrop.sh
@@ -72,19 +72,33 @@ set_section() {
 # Function to collect an error (with immediate display)
 collect_error() {
   local message="$1"
+  local line_number="${2:-${LINENO}}"
   local context="${CURRENT_SCRIPT_SECTION:-Unknown section}"
+  local script_name
+  script_name="$(basename "${BASH_SOURCE[1]:-${0}}")"
 
-  echo "❌ ${message}"
-  COLLECTED_ERRORS+=("${context}: ${message}")
+  # Normalize message to single line (replace newlines with spaces)
+  local clean_message
+  clean_message="$(echo "${message}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+
+  echo "❌ ${clean_message}"
+  COLLECTED_ERRORS+=("[${script_name}:${line_number}] ${context}: ${clean_message}")
 }
 
 # Function to collect a warning (with immediate display)
 collect_warning() {
   local message="$1"
+  local line_number="${2:-${LINENO}}"
   local context="${CURRENT_SCRIPT_SECTION:-Unknown section}"
+  local script_name
+  script_name="$(basename "${BASH_SOURCE[1]:-${0}}")"
 
-  echo "⚠️ ${message}"
-  COLLECTED_WARNINGS+=("${context}: ${message}")
+  # Normalize message to single line (replace newlines with spaces)
+  local clean_message
+  clean_message="$(echo "${message}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+
+  echo "⚠️ ${clean_message}"
+  COLLECTED_WARNINGS+=("[${script_name}:${line_number}] ${context}: ${clean_message}")
 }
 
 # Function to show collected errors and warnings at end
@@ -105,7 +119,7 @@ show_collected_issues() {
   if [[ ${error_count} -gt 0 ]]; then
     echo "ERRORS:"
     for error in "${COLLECTED_ERRORS[@]}"; do
-      echo "  ❌ ${error}"
+      echo "  ${error}"
     done
     echo ""
   fi
@@ -113,7 +127,7 @@ show_collected_issues() {
   if [[ ${warning_count} -gt 0 ]]; then
     echo "WARNINGS:"
     for warning in "${COLLECTED_WARNINGS[@]}"; do
-      echo "  ⚠️ ${warning}"
+      echo "  ${warning}"
     done
     echo ""
   fi

--- a/scripts/server/first-boot.sh
+++ b/scripts/server/first-boot.sh
@@ -148,19 +148,33 @@ set_section() {
 # Function to collect an error (with immediate display)
 collect_error() {
   local message="$1"
+  local line_number="${2:-${LINENO}}"
   local context="${CURRENT_SCRIPT_SECTION:-Unknown section}"
+  local script_name
+  script_name="$(basename "${BASH_SOURCE[1]:-${0}}")"
 
-  show_log "❌ ${message}"
-  COLLECTED_ERRORS+=("${context}: ${message}")
+  # Normalize message to single line (replace newlines with spaces)
+  local clean_message
+  clean_message="$(echo "${message}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+
+  show_log "❌ ${clean_message}"
+  COLLECTED_ERRORS+=("[${script_name}:${line_number}] ${context}: ${clean_message}")
 }
 
 # Function to collect a warning (with immediate display)
 collect_warning() {
   local message="$1"
+  local line_number="${2:-${LINENO}}"
   local context="${CURRENT_SCRIPT_SECTION:-Unknown section}"
+  local script_name
+  script_name="$(basename "${BASH_SOURCE[1]:-${0}}")"
 
-  show_log "⚠️ ${message}"
-  COLLECTED_WARNINGS+=("${context}: ${message}")
+  # Normalize message to single line (replace newlines with spaces)
+  local clean_message
+  clean_message="$(echo "${message}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+
+  show_log "⚠️ ${clean_message}"
+  COLLECTED_WARNINGS+=("[${script_name}:${line_number}] ${context}: ${clean_message}")
 }
 
 # Function to show collected errors and warnings at end
@@ -181,7 +195,7 @@ show_collected_issues() {
   if [[ ${error_count} -gt 0 ]]; then
     show_log "ERRORS:"
     for error in "${COLLECTED_ERRORS[@]}"; do
-      show_log "  ❌ ${error}"
+      show_log "  ${error}"
     done
     show_log ""
   fi
@@ -189,7 +203,7 @@ show_collected_issues() {
   if [[ ${warning_count} -gt 0 ]]; then
     show_log "WARNINGS:"
     for warning in "${COLLECTED_WARNINGS[@]}"; do
-      show_log "  ⚠️ ${warning}"
+      show_log "  ${warning}"
     done
     show_log ""
   fi


### PR DESCRIPTION
- Add script name and line number to each error/warning: [script.sh:123]
- Normalize multi-line messages to single lines for cleaner output
- Remove duplicate emoji display in summary (already shown in collection)
- Fix shellcheck SC2155 warnings by separating variable declarations
- Consistent implementation across all setup scripts

🤖 Generated with [Claude Code](https://claude.ai/code)