### PR TITLE
Fix keychain file naming consistency

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -260,7 +260,7 @@ HOSTNAME_OVERRIDE="unique-hostname"
 ```bash
 # Fix common permission issues
 chmod 755 ~/macmini-setup/scripts/*.sh
-chmod 600 ~/macmini-setup/config/mac-server-setup.keychain-db
+chmod 600 ~/macmini-setup/config/mac-server-setup-db
 chmod 600 ~/macmini-setup/config/wifi_network.conf
 ```
 

--- a/docs/keychain-credential-management.md
+++ b/docs/keychain-credential-management.md
@@ -76,7 +76,7 @@ Retrieves NAS credentials from keychain for SMB mounting, URL-encodes passwords,
 ### Configuration Files
 
 - **keychain_manifest.conf**: Contains service identifiers and keychain metadata
-- **External keychain file**: `mac-server-setup.keychain-db` transferred with setup package
+- **External keychain file**: `mac-server-setup-db` transferred with setup package
 
 ## Error Handling
 

--- a/docs/setup/prep-airdrop.md
+++ b/docs/setup/prep-airdrop.md
@@ -94,7 +94,7 @@ macmini-setup/
 │   ├── casks.txt                # Homebrew applications
 │   ├── dev_fingerprint.conf     # Safety check data
 │   ├── keychain_manifest.conf   # Keychain service identifiers
-│   ├── mac-server-setup.keychain-db # External keychain file
+│   ├── mac-server-setup-db # External keychain file
 │   ├── timemachine.conf         # Backup configuration
 │   ├── apple_id_password.url    # One-time Apple ID link
 │   └── wifi_network.conf        # WiFi credentials (only if script-based config)

--- a/prep-airdrop.sh
+++ b/prep-airdrop.sh
@@ -354,16 +354,16 @@ finalize_external_keychain() {
   # Lock the external keychain
   security lock-keychain "${EXTERNAL_KEYCHAIN}"
 
-  # Get the keychain file path
-  local keychain_file="${HOME}/Library/Keychains/${EXTERNAL_KEYCHAIN}.keychain-db"
+  # Get the keychain file path (macOS creates keychains with -db suffix)
+  local keychain_file="${HOME}/Library/Keychains/${EXTERNAL_KEYCHAIN}-db"
 
   if [[ -f "${keychain_file}" ]]; then
     # Copy keychain file to airdrop package
     cp "${keychain_file}" "${OUTPUT_PATH}/config/"
-    chmod 600 "${OUTPUT_PATH}/config/${EXTERNAL_KEYCHAIN}.keychain-db"
+    chmod 600 "${OUTPUT_PATH}/config/${EXTERNAL_KEYCHAIN}-db"
 
     echo "✅ External keychain added to airdrop package"
-    echo "   Keychain file: ${EXTERNAL_KEYCHAIN}.keychain-db"
+    echo "   Keychain file: ${EXTERNAL_KEYCHAIN}-db"
     echo "   Password: Hardware UUID fingerprint"
 
     # Store keychain password in manifest for server use

--- a/scripts/server/first-boot.sh
+++ b/scripts/server/first-boot.sh
@@ -810,8 +810,8 @@ import_external_keychain_credentials() {
   fi
 
   # Move external keychain file to user's keychain directory
-  local external_keychain_file="${SETUP_DIR}/config/${EXTERNAL_KEYCHAIN}.keychain-db"
-  local user_keychain_file="${HOME}/Library/Keychains/${EXTERNAL_KEYCHAIN}.keychain-db"
+  local external_keychain_file="${SETUP_DIR}/config/${EXTERNAL_KEYCHAIN}-db"
+  local user_keychain_file="${HOME}/Library/Keychains/${EXTERNAL_KEYCHAIN}-db"
 
   if [[ ! -f "${external_keychain_file}" ]]; then
     collect_error "External keychain file not found: ${external_keychain_file}"


### PR DESCRIPTION
macOS creates keychains with -db suffix (not .keychain-db). Updated:
- prep-airdrop.sh: Use correct keychain filename when copying to setup package
- first-boot.sh: Use correct keychain filename when importing from setup package
- Documentation: Update all references to use mac-server-setup-db

This fixes the 'External keychain file not found' error during setup preparation.

🤖 Generated with [Claude Code](https://claude.ai/code)