### PR TITLE
fix: replace ++ increment patterns with += 1 for shellcheck compliance

### DIFF
--- a/app-setup/app-setup-templates/mount-nas-media.sh
+++ b/app-setup/app-setup-templates/mount-nas-media.sh
@@ -60,7 +60,7 @@ wait_for_network() {
 
     log "   Attempt ${attempt}/${max_attempts}: No connectivity to ${NAS_HOSTNAME}, waiting 5 seconds..."
     sleep 5
-    ((attempt++))
+    ((attempt += 1))
   done
 
   log "❌ Failed to establish network connectivity to ${NAS_HOSTNAME} after ${max_attempts} attempts"

--- a/app-setup/app-setup-templates/start-rclone.sh
+++ b/app-setup/app-setup-templates/start-rclone.sh
@@ -62,7 +62,7 @@ wait_for_network() {
 
     log "Network attempt ${attempt}/${max_attempts} - waiting 10s..."
     sleep 10
-    ((attempt++))
+    ((attempt += 1))
   done
 
   log "❌ Network connectivity timeout after ${max_attempts} attempts"

--- a/app-setup/plex-setup.sh
+++ b/app-setup/plex-setup.sh
@@ -888,7 +888,7 @@ main() {
           clean_server=$(echo "${server}" | tr -d '[:space:]')
           log "  ${index}. ${clean_server}"
           server_array+=("${clean_server}")
-          ((index++))
+          ((index += 1))
         done <<<"${discovered_servers}"
 
         log "  ${index}. Other (enter manually)"

--- a/scripts/airdrop/rclone-airdrop-prep.sh
+++ b/scripts/airdrop/rclone-airdrop-prep.sh
@@ -77,7 +77,7 @@ if [[ -n "${DROPBOX_SYNC_FOLDER:-}" ]]; then
         break
       fi
       sleep 1
-      ((config_wait_elapsed++))
+      ((config_wait_elapsed += 1))
     done
 
     if [[ -f "${RCLONE_CONFIG_PATH}" ]]; then

--- a/scripts/server/operator-first-login.sh
+++ b/scripts/server/operator-first-login.sh
@@ -76,7 +76,7 @@ wait_for_network_mount() {
     fi
 
     sleep 1
-    ((elapsed++))
+    ((elapsed += 1))
   done
 
   log "Warning: Network mount not available after ${timeout} seconds"
@@ -126,7 +126,7 @@ setup_dock() {
       log "Removing ${app} from dock..."
       dockutil --remove "${app}" 2>/dev/null || true
       sleep 1
-      ((elapsed++))
+      ((elapsed += 1))
     done
 
     if [[ ${elapsed} -ge ${timeout} ]]; then
@@ -158,7 +158,7 @@ setup_dock() {
       log "Adding ${app} to dock..."
       dockutil --add "${app}" 2>/dev/null || true
       sleep 1
-      ((elapsed++))
+      ((elapsed += 1))
     done
 
     if [[ ${elapsed} -ge ${timeout} ]]; then

--- a/scripts/server/setup-command-line-tools.sh
+++ b/scripts/server/setup-command-line-tools.sh
@@ -440,12 +440,6 @@ main() {
   log ""
   log "✅ Command Line Tools installation and verification completed successfully"
   log ""
-  log "Installed tools verified:"
-  log "• Development tools: clang, git, make, cc, c++"
-  log "• Compiler functionality tested and working"
-  log "• System headers accessible"
-  log ""
-  log "Command Line Tools are ready for use!"
 }
 
 # Execute main function with all arguments


### PR DESCRIPTION
Replaces problematic increment patterns across multiple scripts:
- mount-nas-media.sh: Fixed attempt counter increment
- start-rclone.sh: Fixed attempt counter increment
- plex-setup.sh: Fixed server index counter increment
- rclone-airdrop-prep.sh: Fixed config wait elapsed increment
- operator-first-login.sh: Fixed elapsed counter increments (3 instances)
- setup-command-line-tools.sh: Removed redundant verification output

These changes improve shellcheck compliance by using the more explicit ((variable += 1)) syntax instead of the ambiguous ((variable++)) pattern.

🤖 Generated with [Claude Code](https://claude.ai/code)