### PR TITLE
fix(vpn): use OPERATOR_USERNAME for headless Plex token/notification

### DIFF
--- a/app-setup/transmission-setup.sh
+++ b/app-setup/transmission-setup.sh
@@ -604,6 +604,7 @@ if [[ -f "${BYPASS_TEMPLATE}" ]]; then
   # Deploy with variable substitution (root-owned for PF operations)
   sudo cp "${BYPASS_TEMPLATE}" "${BYPASS_DEST}"
   sudo sed -i '' "s|__SERVER_NAME__|${HOSTNAME}|g" "${BYPASS_DEST}"
+  sudo sed -i '' "s|__OPERATOR_USERNAME__|${OPERATOR_USERNAME}|g" "${BYPASS_DEST}"
   sudo chmod 755 "${BYPASS_DEST}"
   sudo chown root:wheel "${BYPASS_DEST}"
 

--- a/docs/vpn-transmission.md
+++ b/docs/vpn-transmission.md
@@ -323,6 +323,11 @@ The daemon polls every 60 seconds:
 
 Deployed by `transmission-setup.sh` from the template at `app-setup/templates/plex-vpn-bypass.sh`. The deployment creates a root-level LaunchDaemon (PF operations require root).
 
+Template placeholders (replaced during deployment):
+
+- `__SERVER_NAME__`: Server hostname for logging and notifications
+- `__OPERATOR_USERNAME__`: Operator account username for token lookup and notifications
+
 ### Stage 3b Verification
 
 ```bash


### PR DESCRIPTION
## Summary

- Replaces `stat -f%Su /dev/console` console-user detection in `plex-vpn-bypass.sh` with the deploy-time `__OPERATOR_USERNAME__` template variable
- On a headless server with no active GUI session, `stat` returns `(NNN)` (UID in parens) — neither empty nor `"root"` — so the old guard passed but the username was garbage, causing token lookup to fail and `customConnections` to go stale
- Adds `sed` substitution for `__OPERATOR_USERNAME__` in `transmission-setup.sh` so future deployments work correctly

## Files changed

| File | Change |
|------|--------|
| `app-setup/templates/plex-vpn-bypass.sh` | Add `OPERATOR_USERNAME` config var; remove `console_user` detection from `notify()` and `get_plex_token()` |
| `app-setup/transmission-setup.sh` | Add `sed` substitution for `__OPERATOR_USERNAME__` at deploy time |
| `docs/vpn-transmission.md` | Document new template placeholder |

## Live fix on TILSIT

The patched script is already uploaded to `/tmp/plex-vpn-bypass-fixed.sh` on TILSIT. To activate:

```bash
ssh operator@tilsit.local
sudo cp /tmp/plex-vpn-bypass-fixed.sh /usr/local/bin/plex-vpn-bypass.sh
sudo chmod 755 /usr/local/bin/plex-vpn-bypass.sh
sudo launchctl kickstart -k system/com.tilsit.plex-vpn-bypass
tail -f /var/log/tilsit-plex-vpn-bypass.log
```

The daemon will update `customConnections` to the current public IP within 60 seconds.

## Test Plan

- [ ] `shellcheck app-setup/templates/plex-vpn-bypass.sh` — clean
- [ ] `shellcheck app-setup/transmission-setup.sh` — clean
- [ ] Live: apply patch on TILSIT, confirm log shows successful `customConnections` update to current IP (`67.5.106.16`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)