### PR TITLE
fix(vpn): pia-consent daemon + vpn-monitor crash-loop fix

### DIFF
--- a/app-setup/transmission-setup.sh
+++ b/app-setup/transmission-setup.sh
@@ -574,6 +574,12 @@ if [[ -f "${CONSENT_TEMPLATE}" ]]; then
   </array>
   <key>RunAtLoad</key>
   <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${OPERATOR_HOME}/.local/state/${HOSTNAME_LOWER}-pia-proxy-consent-stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>${OPERATOR_HOME}/.local/state/${HOSTNAME_LOWER}-pia-proxy-consent-stderr.log</string>
 </dict>
 </plist>
 EOF


### PR DESCRIPTION
## Summary

- **pia-proxy-consent**: Convert from `StartInterval=60` single-pass job to a `KeepAlive` daemon with a 10s polling loop. The old design caused launchd `ThrottleInterval` escalation: consistent 3-second exits (checking 3 candidate processes serially) caused launchd to back off well beyond 60s, resulting in multi-hour gaps — confirmed by user observation of 90+ minute window where consent dialog went unclicked.
- **vpn-monitor**: Three `|| log "WARNING"` additions on all `launch_transmission` calls prevent `set -e` from crashing the monitor when Transmission takes longer than 6s to start. Previously, this triggered KeepAlive restart storms (Feb 16 log shows 10s restart cycles for 15+ minutes) that prevented Transmission from ever stabilizing, sometimes leaving it bound to the wrong IP.
- **vpn-monitor health check**: New block in main polling loop: if VPN is up but Transmission is not running (crash mid-session or failed initial launch), automatically relaunch with last-known VPN IP.
- **transmission-setup.sh**: Update pia-proxy-consent plist from `StartInterval` to `KeepAlive` to match new daemon pattern, add `StandardOutPath`/`StandardErrorPath` for better log capture.

## Root Causes Fixed

| Symptom | Root Cause |
|---------|------------|
| PIA consent dialog ignored for 90+ min | `StartInterval` job exits in ~3s → launchd throttle escalates past 90min |
| Transmission on wrong IP after VPN restart | `launch_transmission` failure → `set -e` exits monitor → KeepAlive restarts → kill/restart storm |
| No recovery from mid-session Transmission crash | Health check was absent |

## Deployed & Verified on Tilsit

Both scripts deployed and running on the live server:
- `com.tilsit.vpn-monitor`: running, Transmission at PID 87984 on VPN IP
- `com.tilsit.pia-proxy-consent`: running in daemon mode, 10s poll loop active

## Test Plan

- [ ] Reboot tilsit and confirm PIA consent dialog is clicked within 10s of appearing
- [ ] Confirm Transmission binds to VPN IP after boot (check `BindAddressIPv4` pref)
- [ ] Force-quit Transmission manually; confirm vpn-monitor relaunches it within ~5s
- [ ] Disconnect VPN briefly; confirm Transmission is killed then relaunched on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)