### PR TITLE
fix(terminal): fix iTerm2 prefs chown path and username variable

### DIFF
--- a/scripts/server/setup-terminal-profiles.sh
+++ b/scripts/server/setup-terminal-profiles.sh
@@ -335,12 +335,12 @@ import_iterm2_preferences_for_user() {
 
     # Copy preferences file to operator's config directory
     if sudo cp "${preferences_file}" "${operator_library_prefs_dir}" \
-      && sudo chown "${username}:staff" "${operator_library_prefs_dir}/${preferences_file}"; then
-      sudo -iu "{username}" killall iTerm2 &>/dev/null || true
+      && sudo chown "${username}:staff" "${operator_library_prefs_dir}/$(basename "${preferences_file}")"; then
+      sudo -iu "${username}" killall iTerm2 &>/dev/null || true
       sleep 1
-      sudo -iu "{username}" open -a iTerm2 &>/dev/null || true
+      sudo -iu "${username}" open -a iTerm2 &>/dev/null || true
       sleep 1
-      sudo -iu "{username}" killall iTerm2 &>/dev/null || true
+      sudo -iu "${username}" killall iTerm2 &>/dev/null || true
       log "Successfully copied iTerm2 preferences to ${operator_library_prefs_dir}"
       log "Preferences will be imported during operator first login"
       return 0


### PR DESCRIPTION
## Summary

Two bugs in `copy_iterm2_preferences_to_user()` in `scripts/server/setup-terminal-profiles.sh` that caused first-boot.sh to crash during iTerm2 preferences setup:

- **Double-path bug (line 338):** `${operator_library_prefs_dir}/${preferences_file}` — when `preferences_file` is an absolute path (as it is when copied from the airdrop package), this constructs a malformed double-path like `/Users/operator/Library/Preferences//Users/andrewrich/Downloads/tilsit-setup/config/com.googlecode.iterm2.plist`. The `chown` call fails with "No such file or directory," which causes the surrounding `if` block to take the `else` branch, `collect_error` fires, and `first-boot.sh` exits with a non-zero status. Fix: `$(basename "${preferences_file}")` extracts just the filename.

- **Missing `$` on variable (lines 339/341/343):** `"{username}"` is a literal string — bash does not expand it. Every `sudo -iu "{username}"` call silently runs as an undefined user. Fix: `"${username}"`.

## Test plan

- [ ] shellcheck passes with zero warnings/errors
- [ ] Run `first-boot.sh` on TILSIT (or a clean test) with `USE_ITERM2=true` and confirm iTerm2 preferences are copied without error
- [ ] Confirm `chown` target path is `/Users/operator/Library/Preferences/com.googlecode.iterm2.plist` (not a double-path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)