### PR TITLE
docs: update documentation for NFS migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ After setup, these all start automatically on login (LaunchAgents):
 | Catch | Polls ShowRSS feed, grabs new episodes |
 | FileBot | Renames and sorts downloads into the Plex library |
 | rclone | Syncs Dropbox torrent files to the Transmission watch directory |
-| NAS Mount | SMB mount to NAS on login |
+| NAS Mount | NFS mount to NAS on login |
 | Backblaze | Off-site backup |
 | Caddy | Reverse proxy with internal TLS and external HTTPS |
 
@@ -77,7 +77,7 @@ config/config.conf
   └── run-app-setup.sh sources it  (Phase 3)
 ```
 
-Key variables: `SERVER_NAME`, `OPERATOR_USERNAME`, `NAS_HOSTNAME`, `NAS_SHARE_NAME`, `ONEPASSWORD_VAULT`.
+Key variables: `SERVER_NAME`, `OPERATOR_USERNAME`, `NAS_HOSTNAME`, `NAS_SHARE_NAME`, `NAS_VOLUME`, `ONEPASSWORD_VAULT`.
 
 ### Credentials
 
@@ -157,9 +157,9 @@ See [Prerequisites Guide](docs/prerequisites.md) for validation commands.
 │   ├── rclone-setup.sh           # Dropbox sync to watch directory
 │   ├── containers/
 │   │   └── transmission/
-│   │       └── compose.yml       # Podman compose template (haugene)
+│   │       └── compose.yml       # Container configuration reference (haugene)
 │   └── templates/                # Runtime script templates
-│       ├── mount-nas-media.sh    # SMB mount script
+│       ├── mount-nas-media.sh    # NFS mount script
 │       ├── start-plex.sh         # Plex startup wrapper
 │       ├── start-rclone.sh       # rclone sync script
 │       ├── transmission-post-done.sh    # Container-side completion trigger
@@ -261,7 +261,7 @@ Errors block setup. Warnings are optional stuff that wasn't available (SSH keys 
 | `prep-airdrop.sh` | Console output only |
 | `first-boot.sh` | `~/.local/state/<hostname>-setup.log` |
 | App setup scripts | `~/.local/state/<hostname>-app-setup.log` |
-| SMB mount | `~/.local/state/<hostname>-mount.log` |
+| NFS mount | `~/.local/state/<hostname>-mount.log` |
 | Operator login | `~/.local/state/<hostname>-operator-login.log` |
 
 ## Troubleshooting

--- a/docs/apps/plex-setup-README.md
+++ b/docs/apps/plex-setup-README.md
@@ -7,7 +7,7 @@ This document describes the `plex-setup.sh` script for Mac Mini server Plex Medi
 The `plex-setup.sh` script automates native Plex Media Server deployment on macOS with:
 
 - Native Plex Media Server installation via official macOS installer
-- Direct SMB mounting for NAS media storage access
+- NFS mounting for NAS media storage access
 - Shared configuration directory accessible to both admin and operator users
 - LaunchAgent configuration for automatic startup with operator login
 - SSH-based remote migration from existing Plex servers with server discovery
@@ -21,7 +21,7 @@ The `plex-setup.sh` script automates native Plex Media Server deployment on macO
 
 - `--force`: Skip all confirmation prompts
 - `--skip-migration`: Skip Plex configuration migration
-- `--skip-mount`: Skip SMB mount setup
+- `--skip-mount`: Skip NFS mount setup
 - `--server-name NAME`: Set Plex server name (default: hostname)
 - `--migrate-from HOST`: Source hostname for Plex migration
 - `--custom-port PORT`: Set custom port for fresh installations (prevents conflicts)
@@ -56,7 +56,7 @@ The script uses variables from `config.conf`:
 ```bash
 SERVER_NAME="MEDIA"              # Primary server identifier
 OPERATOR_USERNAME="operator"     # Non-admin user account
-NAS_HOSTNAME="nas.local"         # NAS hostname for SMB
+NAS_HOSTNAME="nas.local"         # NAS hostname for NFS
 NAS_SHARE_NAME="Media"           # Media share name
 ONEPASSWORD_PLEX_NAS_ITEM="Plex NAS"  # 1Password item for NAS credentials
 ```
@@ -73,14 +73,14 @@ ONEPASSWORD_PLEX_NAS_ITEM="Plex NAS"  # 1Password item for NAS credentials
 
 1. **Admin setup**: `plex-setup.sh` runs as administrator
    - Installs Plex Media Server application
-   - Embeds NAS credentials directly into SMB mount scripts
+   - Configures NFS mount scripts (NFS uses host-based auth, no credentials embedded)
    - Creates shared configuration directory (`/Users/Shared/PlexMediaServer`)
    - Migrates existing Plex configuration if requested
    - Deploys LaunchAgent and mount scripts to operator account
 
 2. **Operator runtime**: Automatic on operator login
    - LaunchAgent starts Plex with shared configuration
-   - SMB mount uses embedded credentials for media access
+   - NFS mount provides media access (host-based auth, no credentials needed)
    - Plex runs under operator account
 
 ### File Locations
@@ -282,7 +282,7 @@ mount | grep ${NAS_SHARE_NAME}
 ls ~/.local/mnt/${NAS_SHARE_NAME}
 ```
 
-### SMB Mount Management
+### NFS Mount Management
 
 ```bash
 # Manual mount test
@@ -315,7 +315,7 @@ ERRORS:
   ❌ Installing Plex Media Server: Homebrew installation failed
 
 WARNINGS:
-  ⚠️ Setting Up Per-User SMB Mount: Admin SMB mount failed - check credentials
+  ⚠️ Setting Up Per-User NFS Mount: Admin NFS mount failed - check NAS NFS export
   ⚠️ Configuring Remote Migration: SSH connection to old-server.local failed
 
 Review the full log for details: ~/.local/state/macmini-apps.log
@@ -339,9 +339,11 @@ op whoami
 ping ${NAS_HOSTNAME}
 op item get ${ONEPASSWORD_NAS_ITEM}
 
-# Manual SMB mount test
-mkdir -p ~/.local/mnt/${NAS_SHARE_NAME}
-mount_smbfs //${NAS_USERNAME}@${NAS_HOSTNAME}/${NAS_SHARE_NAME} ~/.local/mnt/${NAS_SHARE_NAME}
+# Manual NFS mount test
+sudo mount_nfs -o resvport,rw,soft romano.local:/volume2/DSMedia ~/.local/mnt/${NAS_SHARE_NAME}
+
+# Check NFS exports from NAS
+showmount -e ${NAS_HOSTNAME}
 ```
 
 **Shared Config Access Issues**:

--- a/docs/container-transmission-proposal.md
+++ b/docs/container-transmission-proposal.md
@@ -55,7 +55,7 @@ Replace the entire PIA Desktop + split tunnel + monitoring stack with:
 macOS host
   • Plex.app — unaffected, uses regular internet directly
   • rclone, FileBot, Catch — unaffected
-  • NAS SMB mount — still needed for Plex and trigger-watcher
+  • NAS NFS mount — used by Plex, FileBot, and Finder
   • trigger-watcher LaunchAgent — bridges container done-events to FileBot
 ```
 
@@ -85,7 +85,7 @@ There is no race condition and no "unguarded window."
   and `/dev/net/tun` access required by OpenVPN
 
 Podman uses QEMU for the Linux VM. The VM is named `transmission-vm` and is registered as
-the default Podman connection so `podman compose` targets it without extra flags.
+the default Podman connection so `podman run` targets it without extra flags.
 
 ### 3.2 haugene/transmission-openvpn
 
@@ -151,7 +151,7 @@ simplifies the system significantly and eliminates the only root-level daemon in
 - Plex Media Server (native macOS, uses regular internet — this was always the intent)
 - rclone (cloud backup, unaffected)
 - FileBot + Catch (post-processing pipeline, unaffected)
-- NAS SMB mount LaunchAgent (still needed for Plex's media access)
+- NAS NFS mount LaunchAgent (used by Plex, FileBot, and Finder)
 - All other setup scripts and infrastructure
 
 ---
@@ -163,34 +163,30 @@ simplifies the system significantly and eliminates the only root-level daemon in
 
 ### 5.1 NAS bind mount through Podman VM ✅ RESOLVED
 
-**Original question (OrbStack VirtioFS):** Does the container runtime expose the NAS SMB
-mount or the empty underlying directory?
+**Original question:** Does the container runtime expose the NAS mount through VirtioFS?
 
-**Resolution:** Podman uses QEMU (not Apple Virtualization.framework), so VirtioFS specifics
-don't apply. The macOS-mounted SMB path (`~/.local/mnt/DSMedia`) is bind-mounted directly into
-the Podman VM. `podman-transmission-setup.sh` validates this at deploy time:
+**Resolution (updated 2026-03-16):** VirtioFS pass-through of NFS mounts caused file
+descriptor caching issues — Apple's Virtualization framework holds FDs indefinitely,
+creating `.nfs.*` silly-rename files that block deletion. The solution mounts NFS directly
+inside the Podman VM via a systemd `.mount` unit, bypassing VirtioFS for the data path.
+The container sees the NAS as a native NFS mount (`type nfs4`), not a VirtioFS mount.
 
-```bash
-sudo -iu "${OPERATOR_USERNAME}" podman run --rm \
-  -v "${NAS_MOUNT}:/test:ro" alpine ls /test
-```
+The host-side NFS mount remains for Plex, FileBot, and Finder access. The container
+uses `podman run` (not `podman compose`) because `podman-compose` validates host paths
+and rejects VM-internal mount points.
 
-If the validation fails (NAS not mounted, empty listing), the setup script emits a warning and
-documents the fallback in `docs/container-transmission-proposal.md §5.1`. On reboot, the NAS
-LaunchAgent and the Podman machine start LaunchAgent both fire at login — the machine start
-wrapper does not explicitly wait for the NAS mount, so if the SMB mount is slow, the first
-`compose up` may see an empty `/data`. Recovery: `podman compose up -d` re-runs automatically
-on next login, or manually after confirming the NAS is mounted.
+On reboot, the VM's systemd mount unit starts the NFS mount before the container. The
+`podman-machine-start.sh` wrapper verifies the mount is active before starting the
+container.
 
 ### 5.2 Container startup ordering ✅ RESOLVED
 
 **Resolution:** The Podman machine start LaunchAgent (`com.<host>.podman-transmission-vm`)
 fires at operator login. The wrapper script waits for the Podman socket (up to 30 seconds)
-before running `podman compose up -d`. Both LaunchAgents (NAS mount and Podman machine start)
-run concurrently at login; there is no guaranteed ordering. If the NAS mount isn't ready when
-compose starts, Transmission may start with an empty `/data` bind — this is the same risk as
-§5.1 and has the same recovery path. `restart: unless-stopped` keeps the container running once
-it starts successfully.
+before starting the container. Both LaunchAgents (NAS mount and Podman machine start)
+run concurrently at login; there is no guaranteed ordering. The `podman-machine-start.sh`
+wrapper explicitly checks that the VM's NFS mount is active before starting the container
+with `podman run`, eliminating the startup race condition.
 
 ### 5.3 PIA credentials ✅ RESOLVED
 
@@ -199,7 +195,7 @@ from 1Password and stores them as a combined `username:password` string in the m
 keychain (service: `pia-account-${HOSTNAME_LOWER}`, account: `${HOSTNAME_LOWER}`).
 `podman-transmission-setup.sh` retrieves them at deploy time and writes a `.env` file at
 `~/containers/transmission/.env` (permissions 600, excluded from git). The compose file
-references `${PIA_USERNAME}` and `${PIA_PASSWORD}` from this `.env`.
+references `${PIA_USERNAME}` and `${PIA_PASSWORD}` from this `.env` via `--env-file`.
 
 ### 5.4 Port forwarding handoff mechanism ✅ RESOLVED
 
@@ -310,7 +306,7 @@ existing setup is fully preserved during Phase 1 and Phase 2.
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| NAS SMB mount not ready when Podman machine starts | Medium | High | `restart: unless-stopped` recovers; manual `podman compose up -d` after confirming NAS mount |
+| NAS NFS mount not ready when Podman machine starts | Medium | High | `podman-machine-start.sh` verifies VM NFS mount before starting container; manual recovery via `podman run` after confirming mount |
 | Podman machine updates break container networking | Low | Medium | Pin image versions; Podman is a Homebrew formula with pinnable versions |
 | PIA changes OpenVPN server config or API | Low | High | haugene is actively maintained for PIA; same risk exists with PIA Desktop |
 | haugene port forwarding script fails on PIA API change | Low | Medium | Transmission continues downloading; peering degrades until fixed |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -44,13 +44,14 @@ ONEPASSWORD_OPENSUBTITLES_ITEM="Opensubtitles"
 
 ### NAS Configuration
 
-**Location**: `config/config.conf` or app-setup scripts
+**Location**: `config/config.conf`
 
 ```bash
 # NAS connection details
 NAS_HOSTNAME="nas.local"
 NAS_SHARE_NAME="Media"
 NAS_USERNAME="plex"
+NAS_VOLUME="volume2"              # Synology volume for NFS export path
 ```
 
 ## Advanced Configuration Variables

--- a/docs/keychain-credential-management.md
+++ b/docs/keychain-credential-management.md
@@ -43,7 +43,7 @@ Single-phase admin import process:
 
 1. **Admin Import** - Transfers credentials from external keychain to admin's keychain
 
-**Note**: Operator keychain population has been removed as it's no longer needed. The operator account is created before first login, meaning no login keychain exists yet. SMB credentials are embedded directly into service scripts during application setup, eliminating the need for operator keychain access.
+**Note**: Operator keychain population has been removed as it's no longer needed. The operator account is created before first login, meaning no login keychain exists yet. NFS mount scripts use host-based authentication (no embedded credentials), and other service scripts embed credentials as needed during application setup.
 
 ### Application Usage (app-setup/*.sh)
 
@@ -71,7 +71,7 @@ Services use embedded credentials that were securely inserted during application
 
 ### mount-nas-media.sh Template
 
-Uses embedded NAS credentials that were securely inserted during plex-setup.sh execution. Credentials are validated during script startup, URL-encoded for SMB mounting, and protected by restrictive file permissions (mode 700).
+Mounts the NAS media share via NFS. Unlike the previous SMB approach, NFS uses host-based authentication — no credentials are embedded in the script. The script is still deployed with restrictive permissions (mode 700) since it runs sudo for the mount command.
 
 ### Configuration Files
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -22,7 +22,7 @@ The system is configured to automatically log in as the operator user after rebo
 
 - Remove unnecessary applications (Messages, Mail, Maps, etc.)
 - Add essential server tools (iTerm, Plex Media Server, Passwords)
-- Add network media folder (if SMB mount is available)
+- Add network media folder (if NFS mount is available)
 
 You can monitor the setup progress in the logs:
 
@@ -68,7 +68,7 @@ The automatic setup adds iTerm to the dock. **Switch from Terminal to iTerm** fo
 - **Homebrew Access**: Full access to package management
 - **Application Access**: Access to shared application configurations via staff group membership
 - **Native Application Management**: Designed for running native macOS applications with shared configuration access
-- **Direct SMB Access**: Access to mounted network shares for media management
+- **NFS Mount Access**: Access to mounted network shares for media management
 
 ### Administrative Tasks
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -29,7 +29,7 @@ Required 1Password login items in your configured vault:
 3. **Plex NAS** (item name configurable via `ONEPASSWORD_PLEX_NAS_ITEM`)
    - Username: NAS username for media access
    - Password: NAS password
-   - URL field: NAS hostname or SMB URL (optional)
+   - URL field: NAS hostname (optional, for reference)
 
 4. **Apple ID** (item name configurable via `ONEPASSWORD_APPLEID_ITEM`)
    - Username: Apple ID email


### PR DESCRIPTION
## Summary

Updates all active documentation to reflect the SMB→NFS migration and podman compose→podman run changes from PR #82.

- **7 files updated**, 22 edits across README, plex-setup docs, operator guide, keychain docs, environment variables, container proposal, and prerequisites
- Historical docs (plans/, code-review) left as-is — they document decisions at a point in time
- Key theme: NFS uses host-based auth (no credential embedding), mount scripts use `sudo mount_nfs` with `noowners`

## Test plan

- [x] No stale SMB references in active docs (verified via grep)
- [x] `NAS_VOLUME` documented in environment-variables.md
- [x] Container proposal §5.1 and §5.2 reflect current VirtioFS bypass architecture
- [x] Troubleshooting commands updated (mount_nfs, showmount -e)
- [x] markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)