### PR TITLE
docs: update for NFS watchdog and health check auto-recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Errors block setup. Warnings are optional stuff that wasn't available (SSH keys 
 
 **1Password items not found**: Vault name and item titles in `config.conf` have to match exactly.
 
-**Transmission container not starting**: Check `podman machine list` and `podman logs transmission-vpn`. If the VPN can't connect, verify PIA credentials in the keychain.
+**Transmission container not starting**: Check `podman machine list` and `podman logs transmission-vpn`. If the VPN can't connect, verify PIA credentials in the keychain. The container has a health check that auto-restarts it after 3 minutes of unresponsiveness, and an NFS watchdog inside the VM auto-remounts stale NFS mounts every 2 minutes. Check recovery logs with `sudo -u operator -i bash -c 'podman machine ssh transmission-vm -- journalctl -u nfs-watchdog.service --no-pager -n 20'` and health status with `sudo -u operator -i bash -c 'podman inspect transmission-vpn --format "{{.State.Health.Status}}"'`.
 
 **App not starting on login**: `launchctl list | grep <app>` to check status. Also check `/Users/Shared/` directory permissions.
 

--- a/docs/container-transmission-proposal.md
+++ b/docs/container-transmission-proposal.md
@@ -306,7 +306,8 @@ existing setup is fully preserved during Phase 1 and Phase 2.
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| NAS NFS mount not ready when Podman machine starts | Medium | High | `podman-machine-start.sh` verifies VM NFS mount before starting container; manual recovery via `podman run` after confirming mount |
+| NAS NFS mount not ready when Podman machine starts | Medium | High | `podman-machine-start.sh` verifies VM NFS mount before starting container; NFS watchdog timer inside VM auto-remounts stale mounts every 2 minutes |
+| NFS mount goes stale while running | Medium | High | NFS watchdog (systemd timer) detects stale mount and remounts automatically; container health check restarts Transmission if it becomes unresponsive |
 | Podman machine updates break container networking | Low | Medium | Pin image versions; Podman is a Homebrew formula with pinnable versions |
 | PIA changes OpenVPN server config or API | Low | High | haugene is actively maintained for PIA; same risk exists with PIA Desktop |
 | haugene port forwarding script fails on PIA API change | Low | Medium | Transmission continues downloading; peering degrades until fixed |


### PR DESCRIPTION
## Summary

- Update risk table in `docs/container-transmission-proposal.md` to reflect automated NFS recovery (replaces "manual recovery" with watchdog/health check)
- Add new risk row for NFS mount going stale while running
- Update troubleshooting in `README.md` with auto-recovery info and diagnostic commands

Follow-up to #85.

## Test plan

- [x] Markdown lint passes
- [x] Content is accurate (matches deployed configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)