### PR TITLE
fix(plex-watchdog): prompt for MONITORING_EMAIL, update sender

### DIFF
--- a/app-setup/msmtp-setup.sh
+++ b/app-setup/msmtp-setup.sh
@@ -66,7 +66,6 @@ if [[ -z "${MONITORING_EMAIL:-}" ]] || [[ "${MONITORING_EMAIL}" == "your-email@e
   fi
 
   # Update config.conf with the provided email (escape sed special chars in value)
-  local escaped_email
   escaped_email=$(printf '%s\n' "${MONITORING_EMAIL}" | sed -e 's/[&\|/]/\\&/g')
   sed -i '' "s|^MONITORING_EMAIL=.*|MONITORING_EMAIL=\"${escaped_email}\"|" "${CONFIG_FILE}"
   echo "Updated MONITORING_EMAIL in ${CONFIG_FILE}"

--- a/app-setup/plex-watchdog-setup.sh
+++ b/app-setup/plex-watchdog-setup.sh
@@ -169,7 +169,6 @@ if [[ -z "${MONITORING_EMAIL:-}" ]] || [[ "${MONITORING_EMAIL}" == "your-email@e
     exit 1
   fi
 
-  local escaped_email
   escaped_email=$(printf '%s\n' "${MONITORING_EMAIL}" | sed -e 's/[&\|/]/\\&/g')
   sed -i '' "s|^MONITORING_EMAIL=.*|MONITORING_EMAIL=\"${escaped_email}\"|" "${CONFIG_FILE}"
   log "Updated MONITORING_EMAIL in ${CONFIG_FILE}"


### PR DESCRIPTION
## Summary

- Prompt interactively for MONITORING_EMAIL if not configured in config.conf (both msmtp-setup.sh and plex-watchdog-setup.sh)
- Change msmtp `from` address from `noreply@hostname` to `operator@hostname`

## Context

Found during first deployment to TILSIT — config.conf had the placeholder email, causing setup to fail immediately.

Note: Gmail overrides the `from` field with the authenticated sender (`X-Google-Original-From` preserves the cosmetic address in headers but the displayed sender is still the Gmail account). This is a Gmail limitation, not something we can fix.

## Test plan

- [x] Deployed to TILSIT, test email received
- [x] Watchdog drift detection and revert verified end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)