### PR TITLE
fix(prep-airdrop): guard against service account token in environment

### DIFF
--- a/prep-airdrop.sh
+++ b/prep-airdrop.sh
@@ -98,6 +98,17 @@ if [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]]; then
   exit 0
 fi
 
+# Guard: this script requires interactive 1Password authentication to access
+# the Personal vault. The service account token (set in ~/.config/bash/1password.sh)
+# only has access to the Automation vault.
+# Use 'opp' as a drop-in replacement: opp item get "TimeMachine" --vault personal
+if [[ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+  echo "ERROR: OP_SERVICE_ACCOUNT_TOKEN is set — this script requires interactive 1Password auth." >&2
+  echo "Run with 'opp' prefix for personal vault access, or use a subshell:" >&2
+  echo "  ( unset OP_SERVICE_ACCOUNT_TOKEN; ./$(basename "$0") )" >&2
+  exit 1
+fi
+
 # Error and warning collection system
 COLLECTED_ERRORS=()
 COLLECTED_WARNINGS=()


### PR DESCRIPTION
## Summary
- `prep-airdrop.sh` needs interactive 1Password auth to read the **Personal** vault, but `OP_SERVICE_ACCOUNT_TOKEN` is now exported at shell startup and only grants access to the **Automation** vault — silently causing `op` calls to fail (or return wrong items).
- Add an early guard that exits with a clear message pointing the user at the `opp` subshell wrapper (or an inline `( unset OP_SERVICE_ACCOUNT_TOKEN; ./prep-airdrop.sh )`).

## Test plan
- [x] `shellcheck prep-airdrop.sh` clean
- [x] Local code-reviewer + adversarial-reviewer: PASS
- [x] Pre-push codebase review: PASS
- [ ] Run `./prep-airdrop.sh` with `OP_SERVICE_ACCOUNT_TOKEN` set — expect exit 1 with guidance
- [ ] Run via `opp ./prep-airdrop.sh` (or unset subshell) — expect normal execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)