### PR TITLE
docs: mark host-level PIA VPN bug docs as obsolete

### DIFF
--- a/docs/apps/caddy-cloudflare-checklist.md
+++ b/docs/apps/caddy-cloudflare-checklist.md
@@ -3,6 +3,7 @@
 Commands run in your SSH session on TILSIT unless marked **Dev machine**.
 
 **Status as of 2026-02-23:** Tasks 1, 2, 6, 7-1, 7-2 complete. Resume at **Task 7 retry**.
+**Skip Tasks 9 & 10** — they target the retired host-level PIA stack (see obsolescence notice below).
 
 > **⚠️ Historical — PIA sections obsolete (2026-04-15)**
 >

--- a/docs/apps/caddy-cloudflare-checklist.md
+++ b/docs/apps/caddy-cloudflare-checklist.md
@@ -4,6 +4,17 @@ Commands run in your SSH session on TILSIT unless marked **Dev machine**.
 
 **Status as of 2026-02-23:** Tasks 1, 2, 6, 7-1, 7-2 complete. Resume at **Task 7 retry**.
 
+> **⚠️ Historical — PIA sections obsolete (2026-04-15)**
+>
+> Tasks 9 (`plex-vpn-bypass.sh` live patch) and 10 (removing NoIP DUC from the
+> PIA split-tunnel bypass list) refer to the host-level PIA Desktop + split-
+> tunnel stack that was retired when Transmission moved inside the
+> haugene/transmission-openvpn container. PIA Desktop, the `plex-vpn-bypass`
+> LaunchDaemon, the PF anchor, and the split-tunnel reference files have all
+> been removed from TILSIT. Do not follow those tasks. Cloudflare DNS-01,
+> DDNS, and Caddy TLS tasks (1–8) remain accurate. VPN now runs entirely
+> inside the Transmission container.
+
 ---
 
 ## ✅ Task 1: Store CF_API_TOKEN in System keychain — DONE

--- a/docs/archive/pia-proxy-consent-bug.md
+++ b/docs/archive/pia-proxy-consent-bug.md
@@ -1,5 +1,13 @@
 # PIA macOS Proxy Consent Bug — NE Signature Lost After Reboot
 
+> **⚠️ OBSOLETE (2026-04-15)** — This bug applied only to the host-level PIA
+> Desktop + split-tunnel stack, which was retired when Transmission moved
+> inside the haugene/transmission-openvpn container. PIA Desktop is no longer
+> installed on TILSIT; the `pia-proxy-consent` LaunchAgent, its helper script,
+> and the associated workaround have been removed. VPN now runs entirely inside
+> the Transmission container via OpenVPN (no macOS NE proxy involved). This
+> document is retained as a historical reference only.
+
 ## Summary
 
 After reboot, macOS intermittently loses the Network Extension (NE) proxy consent signature for PIA's split tunnel. When `NETransparentProxyManager.saveToPreferences()` finds `existing signature (null)`, macOS presents a "Would Like to Add Proxy Configurations" dialog requiring user interaction. On a headless server, no one is present to click "Allow", so split tunnel activation is blocked indefinitely.

--- a/docs/archive/pia-split-tunnel-bug.md
+++ b/docs/archive/pia-split-tunnel-bug.md
@@ -7,6 +7,15 @@
 > no longer installed. The container runs OpenVPN at the kernel namespace level
 > with no bypass needed. This document is retained as a historical reference
 > only.
+>
+> **Known residue:** the PIA split-tunnel system extension
+> (`com.privateinternetaccess.vpn.splittunnel`, team `5357M5NW9W`) remains
+> registered as `activated enabled` in `systemextensionsctl list` on TILSIT.
+> `systemextensionsctl uninstall` requires SIP disabled; the extension is
+> inert (no running proxy host process, parent app is uninstalled) and macOS
+> generally garbage-collects orphaned system extensions after reboots. Not
+> worth disabling SIP to chase. If a future operator sees this entry and
+> wonders why — this is the reason.
 
 ## Summary
 

--- a/docs/archive/pia-split-tunnel-bug.md
+++ b/docs/archive/pia-split-tunnel-bug.md
@@ -1,5 +1,13 @@
 # PIA macOS Split Tunnel Bug — Transparent Proxy Failure
 
+> **⚠️ OBSOLETE (2026-04-15)** — This bug only affected the host-level PIA
+> Desktop split-tunnel stack, which was retired when Transmission moved inside
+> the haugene/transmission-openvpn container. The `plex-vpn-bypass` LaunchDaemon
+> and its PF-anchor workaround have been removed from TILSIT; PIA Desktop is
+> no longer installed. The container runs OpenVPN at the kernel namespace level
+> with no bypass needed. This document is retained as a historical reference
+> only.
+
 ## Summary
 
 PIA's macOS split tunnel transparent proxy is broken on macOS 26.3 (Apple Silicon). The proxy correctly identifies bypass apps and binds outbound sockets to the physical interface IP, but data forwarding between the app's network flow and the outbound socket fails for **all** bypass apps. Every proxied session closes with zero bytes transferred.


### PR DESCRIPTION
## Summary

- Adds obsolescence banners to `docs/archive/pia-proxy-consent-bug.md` and `docs/archive/pia-split-tunnel-bug.md` — both described bugs in the host-level PIA Desktop + split-tunnel stack that was retired when Transmission moved inside the haugene/transmission-openvpn container.
- Adds a historical notice to `docs/apps/caddy-cloudflare-checklist.md` flagging that Tasks 9 (live `plex-vpn-bypass.sh` patching) and 10 (PIA split-tunnel bypass list / NoIP DUC) refer to the retired stack — users should skip them. Tasks 1–8 (Cloudflare DNS-01, DDNS, Caddy TLS) remain accurate.
- Container-internal PIA usage (credentials, `PIA_VPN_REGION`, `OPENVPN_PROVIDER=PIA`) is **unchanged** and remains documented in `podman-transmission-setup.sh`, `prep-airdrop.sh`, `first-boot.sh`, and `config.conf.template`.

## Context

Live host cleanup on TILSIT was performed alongside this PR (not part of the commit — system admin only):
- Booted out and removed `/Library/LaunchDaemons/com.tilsit.plex-vpn-bypass.plist` and `/usr/local/bin/plex-vpn-bypass.sh`
- Flushed PF anchor `com.apple/100.tilsit.vpn-bypass`
- Removed `com.tilsit.vpn-monitor` LaunchAgent plist and orphaned `pia-proxy-consent.sh` / `pia-split-tunnel-monitor.sh` scripts under `operator`
- Removed broken `/usr/local/bin/piactl` symlink (PIA Desktop is uninstalled)
- Removed legacy logs under `/var/log/tilsit-plex-vpn-bypass*` and `/Users/operator/.local/state/tilsit-vpn-monitor*`
- Residue: PIA split-tunnel `SystemExtension` registration remains activated/enabled in `systemextensionsctl list` — uninstall requires SIP disabled. Inert (no running extension host process). macOS typically GCs orphaned system extensions after reboots.

Plex remains reachable locally (HTTP 200 on `:32400/identity`) and remotely after removal.

## Test plan

- [x] `plex-vpn-bypass` LaunchDaemon bootout + file removal verified on TILSIT
- [x] PF anchor `com.apple/100.tilsit.vpn-bypass` confirmed empty (`pfctl -s rules`)
- [x] Plex local reachability confirmed (HTTP 200)
- [x] Plex remote reachability confirmed by operator
- [x] `launchctl list` shows no active PIA/VPN entries apart from the SIP-locked system extension stub
- [x] Markdownlint clean for edited files (only pre-existing MD060 table-style issues remain, unchanged)
- [x] Container-internal PIA references (`OPENVPN_PROVIDER=PIA`, `pia-account-tilsit` keychain entry, `PIA_VPN_REGION`) confirmed untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)