### PR TITLE
feat(ddns): add Cloudflare DDNS updater + /media no-slash redirect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,20 @@ with cloudflare module, CF_API_TOKEN injection chain, media file server
 architecture (why Python not Caddy), DNS propagation timing, certmagic
 environment variable syntax (`{$VAR}` vs `{env.VAR}`), ACME state management
 
+### Cloudflare DDNS (public A-record updater)
+
+**Files**: `app-setup/cloudflare-ddns-setup.sh`,
+`app-setup/templates/cloudflare-ddns.sh`,
+`app-setup/templates/com.cloudflare-ddns.plist`,
+`tests/cloudflare-ddns.bats`
+
+**Documentation**: `docs/apps/cloudflare-ddns-README.md`
+
+**Covers**: Why the PIA-era DDNS was retired and how the standalone daemon
+replaces it, System keychain token reuse (same entry Caddy reads), public-IP
+provider fallback chain, change-detection vs heartbeat log cadence, Cloudflare
+API error modes, and the `TEST_RUNNER` hook that lets BATS mock network calls.
+
 ### Transmission-FileBot (media processing pipeline)
 
 **Files**: `app-setup/templates/transmission-done.sh`,
@@ -60,6 +74,7 @@ test architecture (BATS, TEST_RUNNER mode), file stability checks
 ```bash
 # Run all BATS tests
 bats tests/plex-watchdog.bats
+bats tests/cloudflare-ddns.bats
 bats tests/transmission-filebot/**/*.bats
 
 # Lint all shell scripts

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ After setup, these all start automatically on login (LaunchAgents):
 | NAS Mount | NFS mount to NAS on login |
 | Backblaze | Off-site backup |
 | Caddy | Reverse proxy with internal TLS and external HTTPS |
+| Cloudflare DDNS | Keeps the public A record in sync with the WAN IP |
 | Plex Watchdog | Monitors Plex settings against golden config, emails on drift |
 
 ### Media pipeline
@@ -152,6 +153,7 @@ See [Prerequisites Guide](docs/prerequisites.md) for validation commands.
 ├── app-setup/                     # Application setup scripts
 │   ├── run-app-setup.sh          # Orchestrator (runs scripts in dependency order)
 │   ├── caddy-setup.sh            # Caddy reverse proxy deployment
+│   ├── cloudflare-ddns-setup.sh  # Cloudflare A-record DDNS updater
 │   ├── catch-setup.sh            # RSS feed monitor (ShowRSS)
 │   ├── filebot-setup.sh          # Media renaming and sorting
 │   ├── msmtp-setup.sh            # Shared email facility (Gmail SMTP)
@@ -166,6 +168,8 @@ See [Prerequisites Guide](docs/prerequisites.md) for validation commands.
 │       ├── caddy-health.sh        # Caddy endpoint health checker
 │       ├── media-server.py        # Python file server for NFS media
 │       ├── com.caddyserver.caddy.plist  # Caddy LaunchDaemon
+│       ├── com.cloudflare-ddns.plist    # Cloudflare DDNS LaunchDaemon
+│       ├── cloudflare-ddns.sh           # Cloudflare DDNS updater script
 │       ├── com.media-server.plist       # Media server LaunchDaemon
 │       ├── config.yml.template    # Transmission-FileBot pipeline config
 │       ├── mount-nas-media.sh     # NFS mount script

--- a/app-setup/cloudflare-ddns-setup.sh
+++ b/app-setup/cloudflare-ddns-setup.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# cloudflare-ddns-setup.sh — deploy the Cloudflare DDNS updater
+#
+# Installs /usr/local/bin/cloudflare-ddns + /Library/LaunchDaemons/
+# com.<hostname>.cloudflare-ddns.plist, validates the plist, and bootstraps
+# the daemon. The daemon reads CF_API_TOKEN from the System keychain, so the
+# 'cloudflare-api-token' / <external-hostname> entry must already exist
+# (installed during Caddy setup).
+#
+# Usage: sudo ./cloudflare-ddns-setup.sh
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-04-19
+
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "❌ This script requires sudo privileges"
+  echo "   Run: sudo $0"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE_DIR="${SCRIPT_DIR}/templates"
+CONFIG_FILE="${SCRIPT_DIR}/config/config.conf"
+
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  echo "❌ Configuration file not found at ${CONFIG_FILE}"
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "${CONFIG_FILE}"
+
+HOSTNAME_VALUE="${HOSTNAME_OVERRIDE:-${SERVER_NAME:-$(hostname -s)}}"
+HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${HOSTNAME_VALUE}")"
+OPERATOR_USERNAME="${OPERATOR_USERNAME:-operator}"
+EXTERNAL_HOSTNAME="${EXTERNAL_HOSTNAME:-}"
+CLOUDFLARE_ZONE_ID="${CLOUDFLARE_ZONE_ID:-}"
+CLOUDFLARE_RECORD_ID="${CLOUDFLARE_RECORD_ID:-}"
+
+# Validate required config
+missing=()
+[[ -z "${EXTERNAL_HOSTNAME}" ]] && missing+=("EXTERNAL_HOSTNAME")
+[[ -z "${CLOUDFLARE_ZONE_ID}" ]] && missing+=("CLOUDFLARE_ZONE_ID")
+[[ -z "${CLOUDFLARE_RECORD_ID}" ]] && missing+=("CLOUDFLARE_RECORD_ID")
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "❌ Missing required values in ${CONFIG_FILE}:"
+  for var in "${missing[@]}"; do
+    echo "   ${var}"
+  done
+  echo
+  echo "   The zone ID and record ID can be found in the Cloudflare dashboard"
+  echo "   or via \`curl -H 'Authorization: Bearer \$CF_TOKEN' \\"
+  echo "   https://api.cloudflare.com/client/v4/zones/\$ZONE_ID/dns_records\`."
+  exit 1
+fi
+
+# Verify operator user exists
+if ! id -u "${OPERATOR_USERNAME}" >/dev/null 2>&1; then
+  echo "❌ Operator user '${OPERATOR_USERNAME}' not found"
+  exit 1
+fi
+
+# Verify token is present in System keychain
+if ! security find-generic-password \
+  -s "cloudflare-api-token" \
+  -a "${EXTERNAL_HOSTNAME}" \
+  /Library/Keychains/System.keychain >/dev/null 2>&1; then
+  echo "❌ Keychain entry not found:"
+  echo "   service=cloudflare-api-token account=${EXTERNAL_HOSTNAME}"
+  echo
+  echo "   Run Caddy setup first (or add the token manually):"
+  echo "   sudo security add-generic-password -U \\"
+  echo "     -s 'cloudflare-api-token' -a '${EXTERNAL_HOSTNAME}' \\"
+  echo "     -w '<token>' /Library/Keychains/System.keychain"
+  exit 1
+fi
+
+# Deployment paths
+DEPLOY_SCRIPT="/usr/local/bin/cloudflare-ddns"
+DEPLOY_PLIST="/Library/LaunchDaemons/com.${HOSTNAME_LOWER}.cloudflare-ddns.plist"
+DEPLOY_LOG="/Users/${OPERATOR_USERNAME}/.local/state/cloudflare-ddns.log"
+DEPLOY_STATE_DIR="/Users/${OPERATOR_USERNAME}/.local/state"
+
+# Shared substitution — sed delimiter | is safe here (zone/record IDs are hex)
+substitute_template() {
+  local src="$1" dst="$2"
+  sed \
+    -e "s|__HOSTNAME__|${HOSTNAME_VALUE}|g" \
+    -e "s|__HOSTNAME_LOWER__|${HOSTNAME_LOWER}|g" \
+    -e "s|__OPERATOR_USERNAME__|${OPERATOR_USERNAME}|g" \
+    -e "s|__EXTERNAL_HOSTNAME__|${EXTERNAL_HOSTNAME}|g" \
+    -e "s|__CLOUDFLARE_ZONE_ID__|${CLOUDFLARE_ZONE_ID}|g" \
+    -e "s|__CLOUDFLARE_RECORD_ID__|${CLOUDFLARE_RECORD_ID}|g" \
+    "${src}" >"${dst}"
+}
+
+echo "☁️  Deploying Cloudflare DDNS updater for ${HOSTNAME_VALUE}"
+echo "=================================================="
+echo "  External hostname: ${EXTERNAL_HOSTNAME}"
+echo "  Zone ID:           ${CLOUDFLARE_ZONE_ID}"
+echo "  Record ID:         ${CLOUDFLARE_RECORD_ID}"
+echo
+
+# Ensure operator state dir exists and is owned correctly.
+# Non-recursive: other daemons already have state files here and own them.
+mkdir -p "${DEPLOY_STATE_DIR}"
+chown "${OPERATOR_USERNAME}:staff" "${DEPLOY_STATE_DIR}"
+
+# Deploy updater script
+SCRIPT_SOURCE="${TEMPLATE_DIR}/cloudflare-ddns.sh"
+if [[ ! -f "${SCRIPT_SOURCE}" ]]; then
+  echo "❌ Template not found: ${SCRIPT_SOURCE}"
+  exit 1
+fi
+substitute_template "${SCRIPT_SOURCE}" "${DEPLOY_SCRIPT}"
+chown root:wheel "${DEPLOY_SCRIPT}"
+chmod 755 "${DEPLOY_SCRIPT}"
+echo "✓ Installed ${DEPLOY_SCRIPT}"
+
+# Deploy LaunchDaemon plist
+PLIST_SOURCE="${TEMPLATE_DIR}/com.cloudflare-ddns.plist"
+if [[ ! -f "${PLIST_SOURCE}" ]]; then
+  echo "❌ Template not found: ${PLIST_SOURCE}"
+  exit 1
+fi
+substitute_template "${PLIST_SOURCE}" "${DEPLOY_PLIST}"
+chown root:wheel "${DEPLOY_PLIST}"
+chmod 644 "${DEPLOY_PLIST}"
+
+if ! plutil -lint "${DEPLOY_PLIST}" >/dev/null 2>&1; then
+  echo "❌ Invalid plist syntax — launchd will reject ${DEPLOY_PLIST}"
+  plutil -lint "${DEPLOY_PLIST}"
+  exit 1
+fi
+echo "✓ Installed ${DEPLOY_PLIST}"
+
+# Pre-create log file with operator ownership so the daemon (root) writes
+# to it, but operator can tail it without sudo.
+touch "${DEPLOY_LOG}"
+chown "${OPERATOR_USERNAME}:staff" "${DEPLOY_LOG}"
+chmod 644 "${DEPLOY_LOG}"
+
+# (Re)load the LaunchDaemon
+SERVICE_TARGET="system/com.${HOSTNAME_LOWER}.cloudflare-ddns"
+if launchctl print "${SERVICE_TARGET}" >/dev/null 2>&1; then
+  echo "↻ Reloading existing daemon (${SERVICE_TARGET})"
+  launchctl bootout "${SERVICE_TARGET}" 2>/dev/null || true
+fi
+launchctl bootstrap system "${DEPLOY_PLIST}"
+echo "✓ Daemon bootstrapped: ${SERVICE_TARGET}"
+
+# Let the first RunAtLoad cycle complete, then report
+sleep 3
+if [[ -s "${DEPLOY_LOG}" ]]; then
+  echo
+  echo "First log entries:"
+  tail -5 "${DEPLOY_LOG}" | sed 's/^/  /'
+fi
+
+echo
+echo "🚀 Setup complete."
+echo
+echo "Commands:"
+echo "  Status:  sudo launchctl print ${SERVICE_TARGET} | head"
+echo "  Restart: sudo launchctl kickstart -k ${SERVICE_TARGET}"
+echo "  Stop:    sudo launchctl bootout ${SERVICE_TARGET}"
+echo "  Logs:    tail -f ${DEPLOY_LOG}"
+echo "  One-shot manual run: sudo /usr/local/bin/cloudflare-ddns"

--- a/app-setup/run-app-setup.sh
+++ b/app-setup/run-app-setup.sh
@@ -9,6 +9,7 @@
 # 4. catch-setup.sh               - RSS feed automation (monitors for new content)
 # 5. plex-setup.sh                - Media server (serves organized content)
 # 6. caddy-setup.sh               - Caddy reverse proxy (requires sudo)
+# 7. cloudflare-ddns-setup.sh     - Cloudflare A-record DDNS updater (requires sudo, depends on caddy token)
 #
 # Unknown setup scripts are executed after the known ordered scripts.
 #
@@ -108,6 +109,7 @@ while [[ $# -gt 0 ]]; do
       echo "  4. catch-setup.sh               (RSS automation)"
       echo "  5. plex-setup.sh                (Media server)"
       echo "  6. caddy-setup.sh               (Caddy reverse proxy, requires sudo)"
+      echo "  7. cloudflare-ddns-setup.sh     (Cloudflare DDNS updater, requires sudo)"
       echo ""
       exit 0
       ;;
@@ -199,6 +201,7 @@ SCRIPT_ORDER["filebot-setup.sh"]="3:Media file organization"
 SCRIPT_ORDER["catch-setup.sh"]="4:RSS feed automation"
 SCRIPT_ORDER["plex-setup.sh"]="5:Media server"
 SCRIPT_ORDER["caddy-setup.sh"]="6:Caddy reverse proxy (requires sudo)"
+SCRIPT_ORDER["cloudflare-ddns-setup.sh"]="7:Cloudflare DDNS updater (requires sudo; reads keychain token installed by caddy-setup.sh)"
 # Function to get all setup scripts
 get_setup_scripts() {
   local scripts=()
@@ -284,8 +287,9 @@ run_setup_script() {
   # Always pass --force to individual scripts to avoid multiple confirmation prompts
   local cmd=("${script_path}" "--force")
 
-  # caddy-setup.sh requires root for LaunchDaemon and system directory operations
-  if [[ "${script_name}" == "caddy-setup.sh" ]]; then
+  # Scripts that must run as root (LaunchDaemon + /Library writes + System keychain reads)
+  if [[ "${script_name}" == "caddy-setup.sh" ]] \
+    || [[ "${script_name}" == "cloudflare-ddns-setup.sh" ]]; then
     cmd=("sudo" "-E" "${script_path}" "--force")
   fi
 

--- a/app-setup/templates/Caddyfile
+++ b/app-setup/templates/Caddyfile
@@ -74,6 +74,10 @@
 		reverse_proxy localhost:9880
 	}
 
+	# Redirect /media (no trailing slash) to /media/
+	@media_noslash path /media
+	redir @media_noslash /media/ 301
+
 	# Root landing page
 	root * /usr/local/var/www
 	file_server

--- a/app-setup/templates/cloudflare-ddns.sh
+++ b/app-setup/templates/cloudflare-ddns.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+#
+# cloudflare-ddns — Cloudflare A-record DDNS updater
+#
+# Checks the host's current public IP against the A record for __EXTERNAL_HOSTNAME__
+# in Cloudflare, and PATCHes the record if they differ. Runs as root via
+# LaunchDaemon so it can read CF_API_TOKEN from the System keychain.
+#
+# Template placeholders (substituted by cloudflare-ddns-setup.sh):
+#   __EXTERNAL_HOSTNAME__   → public hostname (e.g. tilsit.vip)
+#   __CLOUDFLARE_ZONE_ID__  → Cloudflare zone ID
+#   __CLOUDFLARE_RECORD_ID__→ Cloudflare A-record ID
+#   __OPERATOR_USERNAME__   → service-account name (for log path)
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-04-19
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+EXTERNAL_HOSTNAME="__EXTERNAL_HOSTNAME__"
+CF_ZONE_ID="__CLOUDFLARE_ZONE_ID__"
+CF_RECORD_ID="__CLOUDFLARE_RECORD_ID__"
+OPERATOR_USERNAME="__OPERATOR_USERNAME__"
+
+STATE_DIR="/Users/${OPERATOR_USERNAME}/.local/state"
+LOG_FILE="${STATE_DIR}/cloudflare-ddns.log"
+STATE_FILE="${STATE_DIR}/cloudflare-ddns.state"
+
+CURL_CONNECT_TIMEOUT=5
+CURL_MAX_TIME=15
+HEARTBEAT_INTERVAL_SECONDS=3600
+
+# Public-IP providers tried in order. First provider returning a well-formed
+# IPv4 wins. A malicious provider could return a bogus IP that we'd PATCH into
+# Cloudflare; blast radius is bounded because the Cloudflare token is scoped
+# to a single zone's DNS:Edit permission (set at token creation in the CF
+# dashboard). If the token scope is ever broadened, revisit this choice —
+# cross-validating 2-of-3 providers would be a cheap defense.
+PUBLIC_IP_PROVIDERS=(
+  "https://api.ipify.org"
+  "https://ifconfig.me/ip"
+  "https://icanhazip.com"
+)
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+log() {
+  local level="$1"
+  shift
+  local timestamp
+  timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  printf '[%s] [cloudflare-ddns] %s %s\n' "${timestamp}" "${level}" "$*" >>"${LOG_FILE}"
+}
+
+# ---------------------------------------------------------------------------
+# Token from System keychain (root only)
+# ---------------------------------------------------------------------------
+
+read_cf_token() {
+  security find-generic-password \
+    -s "cloudflare-api-token" \
+    -a "${EXTERNAL_HOSTNAME}" \
+    -w \
+    /Library/Keychains/System.keychain 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Public IP — try providers in order until one returns a valid IPv4
+# ---------------------------------------------------------------------------
+
+is_ipv4() {
+  [[ "$1" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]
+}
+
+# Accept only public, routable IPv4 addresses. A provider hiccup or a
+# transparent proxy could return a private/loopback IP; PATCHing that into
+# the public A-record would take the service offline. Rejects:
+#   - malformed (via is_ipv4)
+#   - any octet >255 (bad format)
+#   - RFC1918 private (10/8, 172.16/12, 192.168/16)
+#   - loopback (127/8), link-local (169.254/16), 0.0.0.0, multicast (224/4+)
+is_public_ipv4() {
+  local ip="$1"
+  is_ipv4 "${ip}" || return 1
+  local -a octets
+  IFS='.' read -ra octets <<<"${ip}"
+  local o
+  for o in "${octets[@]}"; do
+    ((o >= 0 && o <= 255)) || return 1
+  done
+  local a="${octets[0]}" b="${octets[1]}"
+  # 0.0.0.0, loopback, multicast, reserved 240/4
+  ((a == 0 || a == 127 || a >= 224)) && return 1
+  # RFC1918
+  ((a == 10)) && return 1
+  ((a == 172 && b >= 16 && b <= 31)) && return 1
+  ((a == 192 && b == 168)) && return 1
+  # Link-local
+  ((a == 169 && b == 254)) && return 1
+  # CGNAT 100.64/10 — not truly public
+  ((a == 100 && b >= 64 && b <= 127)) && return 1
+  return 0
+}
+
+fetch_public_ip() {
+  local provider ip
+  for provider in "${PUBLIC_IP_PROVIDERS[@]}"; do
+    ip=$(curl -sS \
+      --connect-timeout "${CURL_CONNECT_TIMEOUT}" \
+      --max-time "${CURL_MAX_TIME}" \
+      "${provider}" 2>/dev/null | tr -d '[:space:]') || ip=""
+    if is_public_ipv4 "${ip}"; then
+      printf '%s' "${ip}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Cloudflare API
+# ---------------------------------------------------------------------------
+
+cloudflare_get_record() {
+  local token="$1"
+  curl -sS \
+    --connect-timeout "${CURL_CONNECT_TIMEOUT}" \
+    --max-time "${CURL_MAX_TIME}" \
+    -H "Authorization: Bearer ${token}" \
+    "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records/${CF_RECORD_ID}"
+}
+
+cloudflare_patch_record() {
+  # PATCH is a partial update — fields not sent are preserved. We deliberately
+  # send only `content` so the user's `proxied` (orange-cloud), `ttl`, and any
+  # record-level metadata survive an IP change.
+  local token="$1" new_ip="$2"
+  curl -sS \
+    --connect-timeout "${CURL_CONNECT_TIMEOUT}" \
+    --max-time "${CURL_MAX_TIME}" \
+    -X PATCH \
+    -H "Authorization: Bearer ${token}" \
+    -H "Content-Type: application/json" \
+    --data "$(printf '{"content":"%s"}' "${new_ip}")" \
+    "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records/${CF_RECORD_ID}"
+}
+
+# ---------------------------------------------------------------------------
+# JSON helpers — parse Cloudflare response without needing jq
+# (jq is available on TILSIT, but avoiding a dependency keeps the script
+# self-contained for disaster recovery.)
+# ---------------------------------------------------------------------------
+
+json_field() {
+  local json="$1" field="$2"
+  printf '%s' "${json}" | python3 -c '
+import json, sys
+if len(sys.argv) < 2:
+    sys.exit(1)
+field = sys.argv[1]
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+cur = d
+for part in field.split("."):
+    if isinstance(cur, dict) and part in cur:
+        cur = cur[part]
+    else:
+        sys.exit(0)
+# Emit JSON-native scalars so bash comparisons match the wire format:
+#   true / false (lowercase) for booleans, bare numbers, strings unquoted.
+if isinstance(cur, bool):
+    print("true" if cur else "false")
+elif isinstance(cur, (str, int, float)):
+    print(cur)
+' "${field}" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat — log once per hour when no change is needed, so a silent
+# log doesn't look like the updater is dead.
+# ---------------------------------------------------------------------------
+
+maybe_heartbeat() {
+  local current_ip="$1"
+  local last_heartbeat=0
+  if [[ -f "${STATE_FILE}" ]]; then
+    last_heartbeat=$(awk -F= '$1=="last_heartbeat" {print $2}' "${STATE_FILE}" 2>/dev/null || echo 0)
+    [[ -z "${last_heartbeat}" ]] && last_heartbeat=0
+  fi
+  local now_epoch
+  now_epoch=$(date +%s)
+  local elapsed=$((now_epoch - last_heartbeat))
+  if [[ ${elapsed} -ge ${HEARTBEAT_INTERVAL_SECONDS} ]]; then
+    log "INFO" "heartbeat ok — public=${current_ip} matches ${EXTERNAL_HOSTNAME}"
+    write_state "${current_ip}" "${now_epoch}"
+  else
+    # Update last_ip only; preserve heartbeat timestamp
+    write_state "${current_ip}" "${last_heartbeat}"
+  fi
+}
+
+write_state() {
+  local ip="$1" heartbeat="$2"
+  local tmp="${STATE_FILE}.tmp.$$"
+  {
+    printf 'last_ip=%s\n' "${ip}"
+    printf 'last_heartbeat=%s\n' "${heartbeat}"
+  } >"${tmp}"
+  mv "${tmp}" "${STATE_FILE}"
+}
+
+# ---------------------------------------------------------------------------
+# Main poll cycle
+# ---------------------------------------------------------------------------
+
+main() {
+  mkdir -p "${STATE_DIR}"
+
+  local token
+  token=$(read_cf_token) || token=""
+  if [[ -z "${token}" ]]; then
+    log "ERROR" "cloudflare-api-token not found in System keychain (service=cloudflare-api-token account=${EXTERNAL_HOSTNAME})"
+    exit 1
+  fi
+
+  local public_ip
+  if ! public_ip=$(fetch_public_ip); then
+    log "WARN" "could not determine public IP from any provider — will retry next cycle"
+    exit 0
+  fi
+
+  local cf_response cf_curl_rc cf_success current_ip
+  cf_response=$(cloudflare_get_record "${token}" 2>/dev/null) && cf_curl_rc=0 || cf_curl_rc=$?
+  if [[ ${cf_curl_rc} -ne 0 ]] || [[ -z "${cf_response}" ]]; then
+    # Transient: network/curl failure or empty body. Soft-fail so the next
+    # cycle retries; don't flood monitoring with exit-1 alerts during an
+    # upstream blip.
+    log "WARN" "cloudflare GET unreachable (curl rc=${cf_curl_rc}) — will retry next cycle"
+    exit 0
+  fi
+  cf_success=$(json_field "${cf_response}" "success" || true)
+  if [[ "${cf_success}" != "true" ]]; then
+    # Permanent: CF accepted the request but refused it (token revoked, wrong
+    # zone/record ID, rate limited, etc.). Hard-fail so the error surfaces.
+    log "ERROR" "cloudflare GET rejected — response: ${cf_response}"
+    exit 1
+  fi
+
+  current_ip=$(json_field "${cf_response}" "result.content" || true)
+  if [[ -z "${current_ip}" ]]; then
+    log "ERROR" "cloudflare GET returned no result.content — response: ${cf_response}"
+    exit 1
+  fi
+
+  if [[ "${current_ip}" == "${public_ip}" ]]; then
+    maybe_heartbeat "${public_ip}"
+    exit 0
+  fi
+
+  log "INFO" "IP change detected: ${EXTERNAL_HOSTNAME} ${current_ip} → ${public_ip}"
+
+  local patch_response patch_curl_rc patch_success
+  patch_response=$(cloudflare_patch_record "${token}" "${public_ip}" 2>/dev/null) \
+    && patch_curl_rc=0 || patch_curl_rc=$?
+  if [[ ${patch_curl_rc} -ne 0 ]] || [[ -z "${patch_response}" ]]; then
+    log "WARN" "cloudflare PATCH unreachable (curl rc=${patch_curl_rc}) — will retry next cycle"
+    exit 0
+  fi
+  patch_success=$(json_field "${patch_response}" "success" || true)
+  if [[ "${patch_success}" != "true" ]]; then
+    log "ERROR" "cloudflare PATCH rejected — response: ${patch_response}"
+    exit 1
+  fi
+
+  log "INFO" "cloudflare A-record updated: ${EXTERNAL_HOSTNAME} → ${public_ip}"
+  local now_epoch
+  now_epoch=$(date +%s)
+  write_state "${public_ip}" "${now_epoch}"
+}
+
+# ---------------------------------------------------------------------------
+# Entry point — skipped when sourced for tests (TEST_RUNNER=true)
+# ---------------------------------------------------------------------------
+
+if [[ "${TEST_RUNNER:-false}" != "true" ]]; then
+  main "$@"
+fi

--- a/app-setup/templates/cloudflare-ddns.sh
+++ b/app-setup/templates/cloudflare-ddns.sh
@@ -193,7 +193,9 @@ maybe_heartbeat() {
   local last_heartbeat=0
   if [[ -f "${STATE_FILE}" ]]; then
     last_heartbeat=$(awk -F= '$1=="last_heartbeat" {print $2}' "${STATE_FILE}" 2>/dev/null || echo 0)
-    [[ -z "${last_heartbeat}" ]] && last_heartbeat=0
+    # Guard against a manually-edited state file with a non-numeric value:
+    # `$((now_epoch - garbage))` would hit `set -e` and crash the daemon.
+    [[ "${last_heartbeat}" =~ ^[0-9]+$ ]] || last_heartbeat=0
   fi
   local now_epoch
   now_epoch=$(date +%s)

--- a/app-setup/templates/com.cloudflare-ddns.plist
+++ b/app-setup/templates/com.cloudflare-ddns.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Service identification -->
+    <key>Label</key>
+    <string>com.__HOSTNAME_LOWER__.cloudflare-ddns</string>
+
+    <!-- Runs as root (default for LaunchDaemon) so it can read CF_API_TOKEN
+         from the System keychain via `security find-generic-password`.
+         Invoked via /bin/bash explicitly (same pattern as caddy-wrapper).
+         launchd's default PATH excludes /opt/homebrew/bin, so shebang-based
+         bash-5 resolution can't be relied on here; the script is written to
+         be bash 3.2 compatible (no associative arrays, no mapfile, etc). -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/usr/local/bin/cloudflare-ddns</string>
+    </array>
+
+    <!-- Run one cycle every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <!-- Also run immediately when the daemon is first loaded -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Logging — stdout/stderr redirected to the same file the script uses,
+         so any unexpected output still ends up alongside structured log lines.
+         The parent directory and log file are pre-created with operator:staff
+         ownership by cloudflare-ddns-setup.sh, so root appends leave the file
+         operator-readable (operator can tail/rotate without sudo). -->
+    <key>StandardOutPath</key>
+    <string>/Users/__OPERATOR_USERNAME__/.local/state/cloudflare-ddns.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/__OPERATOR_USERNAME__/.local/state/cloudflare-ddns.log</string>
+
+    <!-- Throttle restart attempts (seconds) -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <!-- Exit timeout -->
+    <key>ExitTimeOut</key>
+    <integer>30</integer>
+</dict>
+</plist>

--- a/docs/apps/cloudflare-ddns-README.md
+++ b/docs/apps/cloudflare-ddns-README.md
@@ -1,0 +1,187 @@
+# Cloudflare DDNS Updater
+
+Keeps the public `A` record for `EXTERNAL_HOSTNAME` in sync with the server's
+current public IPv4 address. Runs every 5 minutes as a LaunchDaemon.
+
+## Why this exists
+
+External access to the server is name-based (`tilsit.vip`) rather than IP-based.
+When the ISP rotates the WAN IP, the Cloudflare record must follow, otherwise
+remote access (Plex, Transmission, the dashboard) breaks.
+
+An earlier DDNS implementation lived inside `plex-vpn-bypass.sh`, which was
+retired 2026-03 when the host-level PIA split-tunnel stack was replaced by a
+VPN-inside-the-container architecture. The A record then drifted silently.
+This updater is the standalone replacement.
+
+## Architecture
+
+```text
+/Library/LaunchDaemons/com.<hostname>.cloudflare-ddns.plist
+  (StartInterval = 300s, runs as root)
+    → /usr/local/bin/cloudflare-ddns
+        ├─ read CF_API_TOKEN from System keychain (same entry Caddy uses)
+        ├─ GET https://api.ipify.org (fallback: ifconfig.me, icanhazip.com)
+        ├─ GET /zones/<ZONE>/dns_records/<RECORD>  → current A-record content
+        ├─ if equal: log heartbeat every 3600s, exit 0
+        └─ if differs: PATCH /zones/<ZONE>/dns_records/<RECORD>, log result
+```
+
+The daemon runs as root so it can call
+`security find-generic-password -s cloudflare-api-token -a <EXTERNAL_HOSTNAME>`
+against the System keychain. The token never lands on disk.
+
+## Files (in `mac-server-setup`)
+
+- `app-setup/cloudflare-ddns-setup.sh` — deploy script; sources `config.conf`,
+  validates inputs, substitutes placeholders, installs the daemon, bootstraps
+  it, and tails the log for confirmation.
+- `app-setup/templates/cloudflare-ddns.sh` — updater script template.
+- `app-setup/templates/com.cloudflare-ddns.plist` — LaunchDaemon plist template.
+- `tests/cloudflare-ddns.bats` — unit tests (IP validator, JSON parser,
+  branch coverage for the main loop with mocked network).
+
+## Deployed paths (on TILSIT)
+
+- `/usr/local/bin/cloudflare-ddns` (mode 0755, root-owned)
+- `/Library/LaunchDaemons/com.<hostname>.cloudflare-ddns.plist` (mode 0644)
+- `/Users/operator/.local/state/cloudflare-ddns.log` — log file
+- `/Users/operator/.local/state/cloudflare-ddns.state` — `last_ip` +
+  `last_heartbeat` epoch
+
+## Configuration
+
+Set these in `app-setup/config/config.conf` before running setup:
+
+```bash
+EXTERNAL_HOSTNAME="tilsit.vip"
+CLOUDFLARE_ZONE_ID="<32-char hex zone ID>"
+CLOUDFLARE_RECORD_ID="<32-char hex record ID>"
+```
+
+The token itself must already be in the System keychain (installed by
+`caddy-setup.sh` / Task 1 of the Cloudflare DNS-01 migration checklist).
+The DDNS setup script checks for the entry and fails loudly if absent.
+
+Find the zone/record IDs from the Cloudflare dashboard or via:
+
+```bash
+CF_TOKEN=$(op read 'op://Personal/.../API/zone DNS API token')
+# Zone ID
+curl -sH "Authorization: Bearer ${CF_TOKEN}" \
+  'https://api.cloudflare.com/client/v4/zones?name=tilsit.vip' \
+  | python3 -m json.tool | grep -E '"id"|"name"'
+# Record ID (after filling in zone ID above)
+curl -sH "Authorization: Bearer ${CF_TOKEN}" \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?type=A" \
+  | python3 -m json.tool
+unset CF_TOKEN
+```
+
+## Deploy / redeploy
+
+```bash
+# On TILSIT, from the app-setup directory
+cd ~/mac-server-setup/app-setup
+sudo ./cloudflare-ddns-setup.sh
+```
+
+The script is idempotent: if the daemon is already loaded it is bootout'd
+before bootstrap. First cycle runs immediately on load (`RunAtLoad=true`).
+
+## Operations
+
+```bash
+# Status
+sudo launchctl print system/com.tilsit.cloudflare-ddns | head
+
+# Force a run now (skip the 5-minute interval)
+sudo launchctl kickstart -k system/com.tilsit.cloudflare-ddns
+
+# Tail the log
+tail -f /Users/operator/.local/state/cloudflare-ddns.log
+
+# Manual one-shot (bypasses the daemon, same effect)
+sudo /usr/local/bin/cloudflare-ddns
+
+# Stop
+sudo launchctl bootout system/com.tilsit.cloudflare-ddns
+
+# Verify current A record from outside the LAN
+dig +short tilsit.vip @1.1.1.1
+```
+
+## Expected log lines
+
+```text
+[2026-04-19 10:00:01] [cloudflare-ddns] INFO heartbeat ok — public=67.5.105.43 matches tilsit.vip
+[2026-04-19 12:05:03] [cloudflare-ddns] INFO IP change detected: tilsit.vip 67.5.105.43 → 67.5.110.22
+[2026-04-19 12:05:04] [cloudflare-ddns] INFO cloudflare A-record updated: tilsit.vip → 67.5.110.22
+[2026-04-19 13:10:02] [cloudflare-ddns] WARN could not determine public IP from any provider — will retry next cycle
+```
+
+Heartbeats fire at most once per hour when nothing changes, so a silent log
+is itself a red flag.
+
+## Troubleshooting
+
+### `cloudflare-api-token not found in System keychain`
+
+The Caddy setup stores this. Verify:
+
+```bash
+sudo security find-generic-password -s cloudflare-api-token -a tilsit.vip \
+  /Library/Keychains/System.keychain
+```
+
+If missing, re-run the Caddy cloudflare checklist Task 1 or add manually:
+
+```bash
+sudo security add-generic-password -U \
+  -s 'cloudflare-api-token' -a 'tilsit.vip' \
+  -w '<token>' /Library/Keychains/System.keychain
+```
+
+### `cloudflare GET failed` / `cloudflare PATCH failed`
+
+The log includes the Cloudflare response JSON. Common causes:
+
+- Token revoked or expired → regenerate in Cloudflare dashboard and update
+  the keychain entry.
+- Token missing `Zone:DNS:Edit` permission on the relevant zone.
+- Zone or record ID drifted (e.g., record deleted and recreated) → look up
+  fresh IDs and redeploy.
+
+### `could not determine public IP from any provider`
+
+All three external providers unreachable. Usually a transient upstream
+outage; the next cycle (5 min) will retry. If persistent:
+
+- `curl -v https://api.ipify.org` from TILSIT directly.
+- Check whether a local DNS or firewall rule is in the way (PIA split
+  tunnel is gone, but VPN changes can recur).
+
+### Record still stale after deploy
+
+`RunAtLoad=true` means the first cycle fires immediately on bootstrap. If
+the record still shows the old IP:
+
+```bash
+tail -20 /Users/operator/.local/state/cloudflare-ddns.log
+sudo launchctl kickstart -k system/com.tilsit.cloudflare-ddns
+```
+
+If the log shows `INFO heartbeat ok — public=X matches ...`, the record
+matches what the script saw. Your cache or the client resolver may still
+hold the old answer; dig directly at Cloudflare (`@1.1.1.1`) to confirm.
+
+## Tests
+
+```bash
+bats tests/cloudflare-ddns.bats
+```
+
+Covers: IPv4 validation, JSON parsing (top-level, dot-path, missing field,
+malformed), main loop with mocked keychain/public-IP/Cloudflare calls for
+both the no-change and change branches, plus failure modes (missing token,
+unreachable IP providers, Cloudflare 4xx).

--- a/tests/cloudflare-ddns.bats
+++ b/tests/cloudflare-ddns.bats
@@ -1,0 +1,398 @@
+#!/usr/bin/env bats
+#
+# Tests for cloudflare-ddns template — validates public-IP detection,
+# JSON parsing, and the change-vs-no-change decision branch.
+#
+# Run with: bats tests/cloudflare-ddns.bats
+
+BATS_TEST_FILENAME="${BATS_TEST_FILENAME:-}"
+REPO_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+TEMPLATE="${REPO_DIR}/app-setup/templates/cloudflare-ddns.sh"
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  export TEST_TMPDIR
+  export STATE_DIR="${TEST_TMPDIR}/state"
+  export LOG_FILE="${STATE_DIR}/cloudflare-ddns.log"
+  export STATE_FILE="${STATE_DIR}/cloudflare-ddns.state"
+  mkdir -p "${STATE_DIR}"
+  touch "${LOG_FILE}"
+
+  # Substitute placeholders + re-pin STATE_DIR/LOG_FILE/STATE_FILE to the
+  # test paths. The override block is appended so it wins over the defaults
+  # hard-coded near the top of the template.
+  local prepared="${TEST_TMPDIR}/cloudflare-ddns.sh"
+  sed \
+    -e 's|__HOSTNAME__|TESTHOST|g' \
+    -e 's|__EXTERNAL_HOSTNAME__|test.example|g' \
+    -e 's|__CLOUDFLARE_ZONE_ID__|zone123|g' \
+    -e 's|__CLOUDFLARE_RECORD_ID__|rec456|g' \
+    -e 's|__OPERATOR_USERNAME__|operator|g' \
+    "${TEMPLATE}" >"${prepared}"
+
+  {
+    echo ""
+    echo "STATE_DIR=\"${STATE_DIR}\""
+    echo "LOG_FILE=\"${LOG_FILE}\""
+    echo "STATE_FILE=\"${STATE_FILE}\""
+  } >>"${prepared}"
+
+  export PREPARED="${prepared}"
+  export TEST_RUNNER=true
+
+  # shellcheck source=/dev/null
+  source "${prepared}"
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+}
+
+# ---------------------------------------------------------------------------
+# is_ipv4 validator
+# ---------------------------------------------------------------------------
+
+@test "is_ipv4: accepts dotted-quad" {
+  run is_ipv4 "192.0.2.1"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_ipv4: rejects empty string" {
+  run is_ipv4 ""
+  [ "$status" -ne 0 ]
+}
+
+@test "is_ipv4: rejects IPv6" {
+  run is_ipv4 "2001:db8::1"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_ipv4: rejects trailing whitespace" {
+  run is_ipv4 "192.0.2.1 "
+  [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# is_public_ipv4 range filter — must reject anything we'd regret PATCHing
+# into the public A record
+# ---------------------------------------------------------------------------
+
+@test "is_public_ipv4: accepts a routable address" {
+  run is_public_ipv4 "67.5.105.43"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_public_ipv4: rejects RFC1918 10/8" {
+  run is_public_ipv4 "10.0.15.4"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_public_ipv4: rejects RFC1918 172.16/12 boundaries" {
+  run is_public_ipv4 "172.16.0.1"
+  [ "$status" -ne 0 ]
+  run is_public_ipv4 "172.31.255.254"
+  [ "$status" -ne 0 ]
+  run is_public_ipv4 "172.32.0.1"
+  [ "$status" -eq 0 ]
+  run is_public_ipv4 "172.15.255.254"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_public_ipv4: rejects RFC1918 192.168/16" {
+  run is_public_ipv4 "192.168.1.1"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_public_ipv4: rejects loopback, link-local, CGNAT, multicast, 0/8" {
+  run is_public_ipv4 "127.0.0.1"
+  [ "$status" -ne 0 ]
+  run is_public_ipv4 "169.254.1.1"
+  [ "$status" -ne 0 ]
+  run is_public_ipv4 "100.64.0.1"
+  [ "$status" -ne 0 ]
+  run is_public_ipv4 "224.0.0.1"
+  [ "$status" -ne 0 ]
+  run is_public_ipv4 "0.0.0.0"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_public_ipv4: rejects out-of-range octet" {
+  run is_public_ipv4 "999.0.0.1"
+  [ "$status" -ne 0 ]
+}
+
+@test "fetch_public_ip: rejects a provider returning a private IP" {
+  curl() {
+    local url="${!#}"
+    case "${url}" in
+      *ipify*) echo "10.0.0.1" ;;
+      *ifconfig*) echo "198.51.100.7" ;;
+      *) return 6 ;;
+    esac
+  }
+  export -f curl
+
+  run fetch_public_ip
+  [ "$status" -eq 0 ]
+  [ "$output" = "198.51.100.7" ]
+}
+
+# ---------------------------------------------------------------------------
+# json_field parsing (covers success / nested / missing paths)
+# ---------------------------------------------------------------------------
+
+@test "json_field: emits JSON-native booleans (lowercase)" {
+  run json_field '{"success": true, "errors": []}' "success"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "json_field: emits JSON-native false" {
+  run json_field '{"success": false}' "success"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+}
+
+@test "json_field: extracts nested dot-path" {
+  run json_field '{"result": {"content": "67.5.105.43"}}' "result.content"
+  [ "$status" -eq 0 ]
+  [ "$output" = "67.5.105.43" ]
+}
+
+@test "json_field: empty output on missing field" {
+  run json_field '{"result": {}}' "result.content"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "json_field: empty output on invalid JSON" {
+  run json_field "not json" "success"
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# main: branch when public IP already matches — no PATCH should happen
+# ---------------------------------------------------------------------------
+
+@test "main: no PATCH when public IP matches current A record" {
+  # Mock keychain
+  read_cf_token() { echo "mock-token"; }
+  # Mock public IP
+  fetch_public_ip() { echo "203.0.113.10"; }
+  # Mock CF GET returning matching IP
+  cloudflare_get_record() {
+    echo '{"success": true, "result": {"content": "203.0.113.10"}}'
+  }
+  # Fail loudly if PATCH is called
+  cloudflare_patch_record() {
+    echo "PATCH SHOULD NOT BE CALLED" >&2
+    return 99
+  }
+  export -f read_cf_token fetch_public_ip cloudflare_get_record cloudflare_patch_record
+
+  run main
+  [ "$status" -eq 0 ]
+  # Log should NOT contain 'IP change detected'
+  run grep -c "IP change detected" "${LOG_FILE}"
+  [ "$output" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# main: branch when public IP differs — PATCH must happen, log reflects it
+# ---------------------------------------------------------------------------
+
+@test "main: PATCH called when public IP differs" {
+  read_cf_token() { echo "mock-token"; }
+  fetch_public_ip() { echo "198.51.100.5"; }
+  cloudflare_get_record() {
+    echo '{"success": true, "result": {"content": "203.0.113.10"}}'
+  }
+  # Echo IP into a witness file so the test can prove PATCH was called
+  cloudflare_patch_record() {
+    echo "$2" >"${TEST_TMPDIR}/patched_ip"
+    echo '{"success": true, "result": {"content": "'"$2"'"}}'
+  }
+  export -f read_cf_token fetch_public_ip cloudflare_get_record cloudflare_patch_record
+
+  run main
+  [ "$status" -eq 0 ]
+  [ -f "${TEST_TMPDIR}/patched_ip" ]
+  [ "$(cat "${TEST_TMPDIR}/patched_ip")" = "198.51.100.5" ]
+  run grep -c "IP change detected" "${LOG_FILE}"
+  [ "$output" = "1" ]
+  run grep -c "cloudflare A-record updated" "${LOG_FILE}"
+  [ "$output" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# main: missing keychain token → exit 1 with error log
+# ---------------------------------------------------------------------------
+
+@test "main: fails when keychain token is missing" {
+  read_cf_token() { return 1; }
+  export -f read_cf_token
+
+  run main
+  [ "$status" -ne 0 ]
+  run grep -c "cloudflare-api-token not found" "${LOG_FILE}"
+  [ "$output" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# main: public-IP fetch fails → exit 0, WARN logged, no CF calls
+# ---------------------------------------------------------------------------
+
+@test "main: public IP fetch failure is a soft-fail (warn, exit 0)" {
+  read_cf_token() { echo "mock-token"; }
+  fetch_public_ip() { return 1; }
+  cloudflare_get_record() {
+    echo "CF GET SHOULD NOT RUN" >&2
+    return 99
+  }
+  export -f read_cf_token fetch_public_ip cloudflare_get_record
+
+  run main
+  [ "$status" -eq 0 ]
+  run grep -c "could not determine public IP" "${LOG_FILE}"
+  [ "$output" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# main: Cloudflare GET failure (success=false) → exit 1 with error
+# ---------------------------------------------------------------------------
+
+@test "main: cloudflare GET rejected (success:false) is a hard-fail" {
+  read_cf_token() { echo "mock-token"; }
+  fetch_public_ip() { echo "198.51.100.5"; }
+  cloudflare_get_record() {
+    echo '{"success": false, "errors": [{"code": 10000, "message": "Authentication failed"}]}'
+  }
+  export -f read_cf_token fetch_public_ip cloudflare_get_record
+
+  run main
+  [ "$status" -ne 0 ]
+  run grep -c "cloudflare GET rejected" "${LOG_FILE}"
+  [ "$output" = "1" ]
+}
+
+@test "main: cloudflare GET network failure is a soft-fail (WARN, exit 0)" {
+  read_cf_token() { echo "mock-token"; }
+  fetch_public_ip() { echo "198.51.100.5"; }
+  # Simulate transient: empty body + nonzero exit
+  cloudflare_get_record() { return 7; }
+  # PATCH must not be reached
+  cloudflare_patch_record() {
+    echo "SHOULD NOT RUN" >&2
+    return 99
+  }
+  export -f read_cf_token fetch_public_ip cloudflare_get_record cloudflare_patch_record
+
+  run main
+  [ "$status" -eq 0 ]
+  run grep -c "cloudflare GET unreachable" "${LOG_FILE}"
+  [ "$output" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# main: Cloudflare PATCH failure → exit 1, change logged but update not confirmed
+# ---------------------------------------------------------------------------
+
+@test "main: cloudflare PATCH rejected (success:false) is a hard-fail" {
+  read_cf_token() { echo "mock-token"; }
+  fetch_public_ip() { echo "198.51.100.5"; }
+  cloudflare_get_record() {
+    echo '{"success": true, "result": {"content": "203.0.113.10"}}'
+  }
+  cloudflare_patch_record() {
+    echo '{"success": false, "errors": [{"code": 9999, "message": "Rate limited"}]}'
+  }
+  export -f read_cf_token fetch_public_ip cloudflare_get_record cloudflare_patch_record
+
+  run main
+  [ "$status" -ne 0 ]
+  run grep -c "cloudflare PATCH rejected" "${LOG_FILE}"
+  [ "$output" = "1" ]
+  run grep -c "cloudflare A-record updated" "${LOG_FILE}"
+  [ "$output" = "0" ]
+}
+
+@test "main: cloudflare PATCH network failure is a soft-fail (WARN, exit 0)" {
+  read_cf_token() { echo "mock-token"; }
+  fetch_public_ip() { echo "198.51.100.5"; }
+  cloudflare_get_record() {
+    echo '{"success": true, "result": {"content": "203.0.113.10"}}'
+  }
+  cloudflare_patch_record() { return 28; } # curl timeout exit code
+  export -f read_cf_token fetch_public_ip cloudflare_get_record cloudflare_patch_record
+
+  run main
+  [ "$status" -eq 0 ]
+  run grep -c "cloudflare PATCH unreachable" "${LOG_FILE}"
+  [ "$output" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# fetch_public_ip: fallback chain — first-provider-bad, second-provider-good
+# ---------------------------------------------------------------------------
+
+@test "fetch_public_ip: falls through to next provider when first returns garbage" {
+  # Override curl: return garbage for first provider, valid IP for second.
+  curl() {
+    local url="${!#}" # last positional
+    case "${url}" in
+      *ipify*) echo "this-is-not-an-ip" ;;
+      *ifconfig*) echo "198.51.100.99" ;;
+      *) return 6 ;;
+    esac
+  }
+  export -f curl
+
+  run fetch_public_ip
+  [ "$status" -eq 0 ]
+  [ "$output" = "198.51.100.99" ]
+}
+
+@test "fetch_public_ip: fails when every provider returns garbage or errors" {
+  curl() {
+    local url="${!#}"
+    case "${url}" in
+      *ipify*) echo "bogus" ;;
+      *ifconfig*) return 28 ;; # curl timeout
+      *icanhazip*) echo "also-bogus" ;;
+      *) return 6 ;;
+    esac
+  }
+  export -f curl
+
+  run fetch_public_ip
+  [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# maybe_heartbeat: log at-most-once per HEARTBEAT_INTERVAL_SECONDS
+# ---------------------------------------------------------------------------
+
+@test "maybe_heartbeat: logs when elapsed exceeds interval" {
+  # Pre-populate state with last_heartbeat far in the past
+  printf 'last_ip=203.0.113.10\nlast_heartbeat=1\n' >"${STATE_FILE}"
+
+  run maybe_heartbeat "203.0.113.10"
+  [ "$status" -eq 0 ]
+  run grep -c "heartbeat ok" "${LOG_FILE}"
+  [ "$output" = "1" ]
+  # last_heartbeat should have advanced (no longer == 1)
+  run grep -E '^last_heartbeat=' "${STATE_FILE}"
+  [[ "$output" != "last_heartbeat=1" ]]
+}
+
+@test "maybe_heartbeat: skips when within interval" {
+  # Set last_heartbeat to just now — well within 3600s window
+  local recent
+  recent=$(date +%s)
+  printf 'last_ip=203.0.113.10\nlast_heartbeat=%s\n' "${recent}" >"${STATE_FILE}"
+
+  run maybe_heartbeat "203.0.113.10"
+  [ "$status" -eq 0 ]
+  run grep -c "heartbeat ok" "${LOG_FILE}"
+  [ "$output" = "0" ]
+}

--- a/tests/cloudflare-ddns.bats
+++ b/tests/cloudflare-ddns.bats
@@ -396,3 +396,15 @@ teardown() {
   run grep -c "heartbeat ok" "${LOG_FILE}"
   [ "$output" = "0" ]
 }
+
+@test "maybe_heartbeat: treats non-numeric last_heartbeat as 0 (no crash)" {
+  # Simulate a hand-edited or corrupt state file — the arithmetic path used
+  # to hit set -e and crash the daemon. It must now degrade to "first run".
+  printf 'last_ip=203.0.113.10\nlast_heartbeat=garbage\n' >"${STATE_FILE}"
+
+  run maybe_heartbeat "203.0.113.10"
+  [ "$status" -eq 0 ]
+  # Non-numeric → treated as 0 → elapsed ≫ 3600 → heartbeat should fire
+  run grep -c "heartbeat ok" "${LOG_FILE}"
+  [ "$output" = "1" ]
+}


### PR DESCRIPTION
## Summary

- **Adds a standalone Cloudflare DDNS updater.** LaunchDaemon runs every 5 minutes, reads the CF API token from the System keychain (same entry Caddy uses), compares public IPv4 to the `tilsit.vip` A record, PATCHes only on change. Replaces the DDNS that used to live inside `plex-vpn-bypass.sh` and was removed during the containerized-Transmission migration. The A record has been stale for ~30 days (manually unblocked from `174.31.4.215` → `67.5.105.43` before this branch).
- **Fixes `/media` (no trailing slash) returning 404** in the Caddy dashboard. Mirrors the existing `/transmission` no-slash redirect pattern two lines above.

## What changed

| File | Purpose |
|------|---------|
| `app-setup/cloudflare-ddns-setup.sh` | Root setup script — validates config, confirms keychain entry, substitutes templates, bootstraps daemon |
| `app-setup/templates/cloudflare-ddns.sh` | Updater; bash 3.2-compatible so launchd's minimal PATH doesn't bite us |
| `app-setup/templates/com.cloudflare-ddns.plist` | LaunchDaemon (root, `StartInterval` 300s, `RunAtLoad`) |
| `app-setup/run-app-setup.sh` | Wired into orchestrator as step 7 (after caddy for keychain dependency) |
| `app-setup/templates/Caddyfile` | 3-line redirect for `/media` → `/media/` |
| `tests/cloudflare-ddns.bats` | 28 tests: IPv4/public-range validation, JSON parsing, main-loop branches (match/change/transient/permanent), provider fallback, heartbeat gating |
| `docs/apps/cloudflare-ddns-README.md` | Service doc: architecture, config, operations, troubleshooting |
| `README.md`, `CLAUDE.md` | Service table + mandatory-read entry |

## Safety-relevant design choices

- **PATCH is content-only.** Cloudflare's PATCH preserves unspecified fields, so user `proxied` (orange-cloud) / `ttl` / other record metadata survive an IP change. (Earlier draft sent `"proxied": false` unconditionally — caught in review.)
- **Public-IP range filter.** A provider hiccup or a transparent proxy could return an RFC1918/loopback/link-local address; PATCHing that into the public record would take the service offline. `is_public_ipv4` rejects `10/8`, `172.16/12`, `192.168/16`, `127/8`, `169.254/16`, `100.64/10`, `224/4+`, and `0.0.0.0`.
- **Transient vs permanent error split.** `curl` failure or empty body → WARN + exit 0 (next cycle retries). `success: false` from Cloudflare (revoked token, wrong zone ID, rate limit) → ERROR + exit 1. Before the split, both scenarios looked identical in logs.
- **Token scope is the real safety net** for the public-IP provider chain; documented as a comment in `cloudflare-ddns.sh`.

## Test plan

- [x] `bats tests/cloudflare-ddns.bats` — 28/28 pass
- [x] `bats tests/plex-watchdog.bats tests/logrotate-globs.bats tests/transmission-filebot/**/*.bats` — no regressions
- [x] `shellcheck --severity=warning --exclude=SC2312` clean on all new/modified shell files
- [x] `shfmt -d -i 2 -ci -bn` clean
- [x] `plutil -lint` valid on plist
- [x] Caddy validate with substituted placeholders — adapter accepts the new config
- [x] Script verified bash-3.2 compatible (parse + `is_public_ipv4` + `json_field`)
- [x] Manual Cloudflare PATCH confirmed working (unblock before the feature lands)
- [ ] Deploy on TILSIT via `sudo ./cloudflare-ddns-setup.sh` and confirm heartbeat line within the first cycle (post-merge)
- [ ] Verify `dig +short tilsit.vip @1.1.1.1` matches `curl -s https://api.ipify.org` after a WAN IP rotation (long-tail verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)