### PR TITLE
fix(podman): prevent VirtioFS→NFS data loss and boot-order race

### DIFF
--- a/app-setup/podman-transmission-setup.sh
+++ b/app-setup/podman-transmission-setup.sh
@@ -512,6 +512,22 @@ log_ts() {
     echo "[\${ts}] \$*"
 }
 
+wait_for_nfs() {
+    local mount_point="${NFS_MOUNT_POINT}"
+    local max_wait=120
+    local elapsed=0
+    while ! /sbin/mount | grep -q " on \${mount_point} "; do
+        log_ts "waiting for NFS mount at \${mount_point} (\${elapsed}/\${max_wait}s)..."
+        sleep 5
+        elapsed=\$((elapsed + 5))
+        if (( elapsed >= max_wait )); then
+            log_ts "FATAL: NFS mount not available at \${mount_point} after \${max_wait}s"
+            return 1
+        fi
+    done
+    log_ts "NFS mount ready at \${mount_point}"
+}
+
 ensure_machine() {
     local state
     state=\$(podman machine inspect transmission-vm --format '{{.State}}' 2>/dev/null || echo unknown)
@@ -563,7 +579,7 @@ ensure_container() {
         -e "PGID=${PGID}" \\
         -e "TZ=${TZ_VALUE}" \\
         -e TRANSMISSION_DOWNLOAD_DIR=/data/Media/Torrents/pending-move \\
-        -e TRANSMISSION_INCOMPLETE_DIR=/data/Media/Torrents/incomplete \\
+        -e TRANSMISSION_INCOMPLETE_DIR_ENABLED=false \\
         -e TRANSMISSION_WATCH_DIR=/watch \\
         -e TRANSMISSION_WATCH_DIR_ENABLED=true \\
         -e TRANSMISSION_RATIO_LIMIT_ENABLED=false \\
@@ -579,6 +595,7 @@ ensure_container() {
         haugene/transmission-openvpn:latest
 }
 
+wait_for_nfs || exit 1
 ensure_machine
 ensure_container
 
@@ -790,7 +807,7 @@ else
     -e "PGID=${PGID}" \
     -e "TZ=${TZ_VALUE}" \
     -e TRANSMISSION_DOWNLOAD_DIR=/data/Media/Torrents/pending-move \
-    -e TRANSMISSION_INCOMPLETE_DIR=/data/Media/Torrents/incomplete \
+    -e TRANSMISSION_INCOMPLETE_DIR_ENABLED=false \
     -e TRANSMISSION_WATCH_DIR=/watch \
     -e TRANSMISSION_WATCH_DIR_ENABLED=true \
     -e TRANSMISSION_RATIO_LIMIT_ENABLED=false \


### PR DESCRIPTION
## Summary
- **Disable Transmission's `incomplete-dir`** to eliminate cross-directory renames over VirtioFS→NFS (soft mount), which silently lost data for 3 torrents on 2026-05-08/10
- **Add `wait_for_nfs()` guard** before starting the Podman VM, closing a boot-order race where the VM could start before the NFS mount was ready (observed 7s gap on 2026-05-14 reboot)

## Root cause
With `incomplete-dir-enabled: true`, Transmission renames completed files from `incomplete/` → `pending-move/` (cross-directory). This rename traverses Container → VirtioFS → Host NFS (soft, timeo=10) → NAS. When the soft mount returns EIO, VirtioFS may already have unlinked the source entry from its cache, leaving files in neither directory — data lost.

## Changes
- `podman-transmission-setup.sh`: replaced `TRANSMISSION_INCOMPLETE_DIR=…` with `TRANSMISSION_INCOMPLETE_DIR_ENABLED=false` in both the heredoc wrapper template and the Section 11 setup-time `podman run`
- Added `wait_for_nfs()` function (120s timeout, 5s poll) called with `|| exit 1` before `ensure_machine()`

## Test plan
- [x] Deployed to TILSIT live — container running with `incomplete-dir-enabled: False` confirmed via Transmission settings.json
- [x] NFS wait function tested on reboot — logged "NFS mount ready" before VM start
- [x] Torrents downloading successfully to `pending-move/` directly
- [x] shellcheck -S info passes clean
- [x] Both code-reviewer and adversarial-reviewer pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)