### PR TITLE
fix(podman): add VirtioFS /data/ health check to supervision loop

### DIFF
--- a/app-setup/podman-transmission-setup.sh
+++ b/app-setup/podman-transmission-setup.sh
@@ -609,11 +609,11 @@ check_data_access() {
             podman machine stop transmission-vm 2>/dev/null || true
             sleep 5
             if ensure_machine && ensure_container; then
-                DATA_CHECK_FAILURES=0
                 log_ts "RECOVERY: VM and container restarted successfully"
             else
                 log_ts "RECOVERY: restart failed — will retry next cycle"
             fi
+            DATA_CHECK_FAILURES=0
         fi
         return 1
     fi

--- a/app-setup/podman-transmission-setup.sh
+++ b/app-setup/podman-transmission-setup.sh
@@ -608,12 +608,11 @@ check_data_access() {
             podman rm -f transmission-vpn 2>/dev/null || true
             podman machine stop transmission-vm 2>/dev/null || true
             sleep 5
-            if ensure_machine; then
-                ensure_container
+            if ensure_machine && ensure_container; then
                 DATA_CHECK_FAILURES=0
                 log_ts "RECOVERY: VM and container restarted successfully"
             else
-                log_ts "RECOVERY: VM restart failed — will retry next cycle"
+                log_ts "RECOVERY: restart failed — will retry next cycle"
             fi
         fi
         return 1

--- a/app-setup/podman-transmission-setup.sh
+++ b/app-setup/podman-transmission-setup.sh
@@ -595,6 +595,36 @@ ensure_container() {
         haugene/transmission-openvpn:latest
 }
 
+DATA_CHECK_FAILURES=0
+MAX_DATA_FAILURES=3
+
+check_data_access() {
+    if ! podman exec transmission-vpn ls /data/ >/dev/null 2>&1; then
+        DATA_CHECK_FAILURES=\$((DATA_CHECK_FAILURES + 1))
+        log_ts "WARNING: /data/ inaccessible inside container (failure \${DATA_CHECK_FAILURES}/\${MAX_DATA_FAILURES})"
+        if (( DATA_CHECK_FAILURES >= MAX_DATA_FAILURES )); then
+            log_ts "RECOVERY: cycling VM to refresh VirtioFS NFS handles"
+            podman stop transmission-vpn 2>/dev/null || true
+            podman rm -f transmission-vpn 2>/dev/null || true
+            podman machine stop transmission-vm 2>/dev/null || true
+            sleep 5
+            if ensure_machine; then
+                ensure_container
+                DATA_CHECK_FAILURES=0
+                log_ts "RECOVERY: VM and container restarted successfully"
+            else
+                log_ts "RECOVERY: VM restart failed — will retry next cycle"
+            fi
+        fi
+        return 1
+    fi
+    if (( DATA_CHECK_FAILURES > 0 )); then
+        log_ts "data access restored after \${DATA_CHECK_FAILURES} failure(s)"
+    fi
+    DATA_CHECK_FAILURES=0
+    return 0
+}
+
 wait_for_nfs || exit 1
 ensure_machine
 ensure_container
@@ -603,7 +633,11 @@ log_ts "entering supervision loop (interval=\${SUPERVISE_INTERVAL}s)"
 while true; do
     sleep "\${SUPERVISE_INTERVAL}"
     if ensure_machine; then
-        ensure_container || log_ts "ensure_container failed — will retry next cycle"
+        if ensure_container; then
+            check_data_access || log_ts "data access check failed — will retry next cycle"
+        else
+            log_ts "ensure_container failed — will retry next cycle"
+        fi
     else
         log_ts "ensure_machine failed — will retry next cycle"
     fi

--- a/docs/apps/transmission-filebot-README.md
+++ b/docs/apps/transmission-filebot-README.md
@@ -305,6 +305,41 @@ When Transmission runs in a container (e.g., podman/haugene), it cannot directly
 4. It invokes `transmission-done.sh` with the correct `TR_TORRENT_*` environment variables
 5. Dead-letter handling: after 5 failures, triggers are moved to `.dead` for manual inspection
 
+### VirtioFS NFS Access and Full Disk Access
+
+The Podman VM shares host directories into the container via VirtioFS. For NFS-backed
+paths (like `/Users/operator/.local/mnt/DSMedia`), macOS enforces TCC/sandbox
+restrictions on the `com.apple.Virtualization.VirtualMachine` XPC service that
+handles VirtioFS I/O.
+
+**Symptom:** Container shows "Operation not permitted" on `/data/` while the
+host NFS mount works fine. `stat()` succeeds but `opendir()` fails (EPERM).
+Other VirtioFS mounts to local paths (`/scripts`, `/config`, `/watch`) work.
+
+**Root cause:** The Virtualization.framework XPC service lacks Full Disk Access
+(FDA). On startup, VirtioFS opens directory handles that work for days/weeks.
+When the NFS server's idle timeout expires those handles, the XPC service
+must re-open them — and gets blocked by the sandbox.
+
+**Fix:** Grant FDA to the Virtualization.framework binary via System Settings >
+Privacy & Security > Full Disk Access:
+
+```text
+/System/Library/Frameworks/Virtualization.framework/Versions/A/XPCServices/
+  com.apple.Virtualization.VirtualMachine.xpc/Contents/MacOS/
+  com.apple.Virtualization.VirtualMachine
+```
+
+**Defense in depth:** The supervision loop in `podman-machine-start.sh` includes
+a `/data/` read health check. If `/data/` is inaccessible for 3 consecutive
+checks (15 minutes at 300s intervals), the loop automatically cycles the Podman
+VM and recreates the container to obtain fresh VirtioFS handles.
+
+> **Note:** This is the same class of issue as the LaunchAgent NFS `opendir()`
+> EPERM (fixed 2026-04-04 by granting FDA to `/bin/bash`). macOS Tahoe
+> enforces NFS access restrictions at the kernel level for any process
+> without FDA, including system XPC services.
+
 ## Common Gotchas
 
 1. **PATH issues**: Transmission runs scripts with minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). Script adds `/usr/local/bin:/opt/homebrew/bin` explicitly for Homebrew tools.


### PR DESCRIPTION
## Summary

- Add `check_data_access()` to the supervision loop in `podman-machine-start.sh` that tests `/data/` readability inside the container every 5 minutes
- After 3 consecutive failures (15 min), automatically cycles the Podman VM and recreates the container to obtain fresh VirtioFS handles
- Document the FDA requirement for `com.apple.Virtualization.VirtualMachine` and the VirtioFS NFS EPERM failure mode

## Context

macOS's `com.apple.Virtualization.VirtualMachine` XPC service (which handles VirtioFS) needs Full Disk Access to `opendir()` NFS-backed paths. Without it, VirtioFS works for days/weeks using cached directory handles, then silently fails with EPERM when the NFS idle timeout expires those handles. The container reports "Operation not permitted" on `/data/` while the host NFS mount remains healthy.

Discovered during a 5-day outage (2026-06-24 through 2026-06-29) where all torrents were stalled because the container couldn't access its data volume.

## Test plan

- [ ] Verify `shellcheck -S info` passes on `podman-transmission-setup.sh`
- [ ] Verify the heredoc generates correct bash (no escaped variables leaking)
- [ ] Confirm the deployed supervision script on TILSIT matches the template output
- [ ] Confirm container is healthy and `/data/` is accessible after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtcszCjRh1cUTNCYL33srq