### PR TITLE
docs(plex): document server update policy as manual

### DIFF
--- a/docs/apps/plex-setup-README.md
+++ b/docs/apps/plex-setup-README.md
@@ -260,6 +260,25 @@ Even in `--force` mode, these elements remain interactive:
 - **Server discovery**: When migration is manually specified via `--migrate-from`
 - **Plex application launch**: GUI application startup requires user session
 
+## Server Update Policy
+
+Plex Media Server's built-in updater (Settings → General → Server version)
+is set to **"Ask me"**, not automatic install. This is intentional, not an
+oversight:
+
+- On headless macOS, "Automatically download and install updates" still
+  relies on a GUI installer step. With no one logged into Plex Web to
+  approve/acknowledge it, an update can hang indefinitely mid-install,
+  taking the server down until someone logs in as `operator` to clear it.
+- "Ask me" avoids that failure mode. The tradeoff is that PMS version
+  updates are applied manually — see "Common Issues" below or update via
+  the Plex Web GUI when convenient.
+
+There is no scripted/headless PMS updater in this repo (the auto-update
+tooling in `scripts/server/setup-auto-updates.sh` covers Homebrew, the Mac
+App Store, and macOS Software Update only — it does not touch Plex). If
+that changes in the future, update this section.
+
 ## Manual Operations
 
 ### Service Management

--- a/docs/apps/plex-watchdog-README.md
+++ b/docs/apps/plex-watchdog-README.md
@@ -8,10 +8,10 @@ The watchdog polls the Plex REST API every 5 minutes, comparing current settings
 
 Two setup scripts deploy four components:
 
-| Script | What it deploys |
-|--------|----------------|
-| `msmtp-setup.sh` | Shared email facility (Gmail SMTP via msmtp) |
-| `plex-watchdog-setup.sh` | Polling daemon, CLI tool, golden config, LaunchAgent |
+| Script                   | What it deploys                                       |
+|--------------------------|-------------------------------------------------------|
+| `msmtp-setup.sh`         | Shared email facility (Gmail SMTP via msmtp)          |
+| `plex-watchdog-setup.sh` | Polling daemon, CLI tool, golden config, LaunchAgent  |
 
 ## Setup
 
@@ -101,7 +101,9 @@ This sends a PUT to the Plex API for each drifted setting and verifies the chang
 
 ### Refreshing after Plex updates
 
-After a Plex update, new settings may appear. Refresh the golden config to pick them up:
+Plex Media Server updates are applied manually (server version updates are
+set to "Ask me" — see `docs/apps/plex-setup-README.md#server-update-policy`).
+After you install one, new settings may appear. Refresh the golden config to pick them up:
 
 ```bash
 sudo -iu operator plex-watchdog-ctl refresh
@@ -162,14 +164,14 @@ The watchdog tracks which drifts have been emailed in `state.json`. It only emai
 Credentials are embedded in config files with restrictive permissions (mode 600, owned by operator) rather than stored in macOS Keychain. This is because the operator keychain cannot be unlocked from non-interactive contexts like LaunchAgents. See [Keychain Management](../keychain-credential-management.md) for details on this project-wide pattern.
 
 | Credential | Location | Protection |
-|-----------|----------|------------|
+| ----------- | ---------- | ------------ |
 | Plex token | `~/.config/plex-watchdog/token` | mode 600, operator:staff |
 | Gmail App Password | `~/.config/msmtp/config` | mode 600, operator:staff |
 
 ## Configuration reference
 
 | Variable | Source | Description |
-|----------|--------|-------------|
+| ---------- | -------- | ------------- |
 | `MONITORING_EMAIL` | `config/config.conf` | Email address for alert delivery |
 | `SERVER_NAME` | `config/config.conf` | Used in email subject prefix (e.g., `[TILSIT]`) |
 | `OPERATOR_USERNAME` | `config/config.conf` | User account that runs the watchdog |
@@ -177,7 +179,7 @@ Credentials are embedded in config files with restrictive permissions (mode 600,
 ## Logs
 
 | Log | Location | Contents |
-|-----|----------|----------|
+| ----- | ---------- | ---------- |
 | Watchdog | `~/.local/state/plex-watchdog.log` | Drift events, heartbeats, errors |
 | msmtp | `~/.local/state/msmtp.log` | Email send attempts and results |
 | Setup | `~/.local/state/<host>-msmtp-setup.log` | msmtp installation log |


### PR DESCRIPTION
## Summary
- Adds a "Server Update Policy" section to `docs/apps/plex-setup-README.md` documenting that Plex Server version updates are intentionally set to "Ask me" (not automatic install), with the reasoning: on headless macOS the built-in updater's install step needs a GUI session, and without one an update can hang the server indefinitely.
- Cross-references that section from the "Refreshing after Plex updates" note in `docs/apps/plex-watchdog-README.md`, so it's not misread as implying auto-update is active.
- Confirms `scripts/server/setup-auto-updates.sh` (Homebrew/MAS/macOS Software Update) does not touch Plex, closing a documentation gap rather than fixing an incorrect claim — no doc previously stated the Plex update policy at all.

## Test plan
- [x] Docs-only change; local pre-push review (adversarial + codebase reviewer) passed
- [ ] CI

https://claude.ai/code/session_01EzGrLLZRr7n62QPe5dpVkq