### PR TITLE
fix(transmission-done): check file exists before stat in rotate_log

### DIFF
--- a/app-setup/templates/transmission-done.sh
+++ b/app-setup/templates/transmission-done.sh
@@ -1401,10 +1401,12 @@ triage_failed_torrent() {
 }
 
 rotate_log() {
-  local log_file_stat
-  log_file_stat="$(stat -f%z "${LOG_FILE}")"
-  if [[ -f "${LOG_FILE}" ]] && [[ "${log_file_stat}" -gt ${MAX_LOG_SIZE} ]]; then
-    mv "${LOG_FILE}" "${LOG_FILE}.old"
+  if [[ -f "${LOG_FILE}" ]]; then
+    local log_file_stat
+    log_file_stat="$(stat -f%z "${LOG_FILE}")"
+    if [[ "${log_file_stat}" -gt ${MAX_LOG_SIZE} ]]; then
+      mv "${LOG_FILE}" "${LOG_FILE}.old"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary
- `rotate_log()` called `stat -f%z` on `LOG_FILE` before checking whether it existed, producing a stderr error on first run.
- Reorders the check so `[[ -f "${LOG_FILE}" ]]` gates the `stat` call, following the existing script's style.

## Test plan
- [x] `shellcheck -S info app-setup/templates/transmission-done.sh` — clean
- [x] `./run_tests.sh` — all unit and integration tests pass (95 unit, 33 integration)
- [x] Local pre-commit and pre-push review hooks passed (code-reviewer, adversarial-reviewer, full-diff review, codebase review)

Fixes #111