### PR TITLE
fix(transmission-done): report df failure distinctly from low disk space

### DIFF
--- a/app-setup/templates/transmission-done.sh
+++ b/app-setup/templates/transmission-done.sh
@@ -554,7 +554,18 @@ classify_failure() {
 check_disk_space() {
   local required_space=1000000 # 1GB in KB
 
-  if ! df -P "${PLEX_MEDIA_PATH}" | awk -v space="${required_space}" 'NR==2 {exit($4<space)}'; then
+  local df_output
+  df_output=$(df -P "${PLEX_MEDIA_PATH}" 2>&1)
+  local df_exit=$?
+
+  if [[ ${df_exit} -ne 0 ]]; then
+    log "Error: Unable to check disk space (df failed, exit code ${df_exit})"
+    log "Path may be inaccessible: ${PLEX_MEDIA_PATH}"
+    log "df output: ${df_output}"
+    return 1
+  fi
+
+  if ! echo "${df_output}" | awk -v space="${required_space}" 'NR==2 {exit($4<space)}'; then
     log "Error: Insufficient space on target filesystem (need ${required_space}KB)"
     return 1
   fi


### PR DESCRIPTION
## Summary
- `check_disk_space()` piped `df` directly into `awk` without checking `df`'s exit code, so a failing `df` (e.g. an NFS mount going unavailable) was silently swallowed and reported as "Insufficient space" instead of the actual cause.
- Captures `df`'s output and exit code first; when `df` fails, logs a distinct error indicating the path may be inaccessible (with the `df` exit code and raw output) instead of reusing the low-disk-space message.

## Test plan
- [x] `shellcheck -S info app-setup/templates/transmission-done.sh` — clean
- [x] `./run_tests.sh` — all unit and integration tests pass
- [x] Local pre-commit / pre-push reviews (code-reviewer, adversarial-reviewer, full-diff, codebase review) — all PASS

Fixes #109