### PR TITLE
fix(caddy): deploy and template-substitute caddy-health.sh

### DIFF
--- a/app-setup/caddy-setup.sh
+++ b/app-setup/caddy-setup.sh
@@ -47,6 +47,7 @@ DEPLOY_WEB_ROOT="/usr/local/var/www"
 DEPLOY_LOG_DIR="/usr/local/var/log/caddy"
 DEPLOY_STATE_DIR="/Users/${OPERATOR_USERNAME}/.local/state/caddy"
 DEPLOY_WRAPPER="/usr/local/bin/caddy-wrapper.sh"
+DEPLOY_HEALTH="/usr/local/bin/caddy-health.sh"
 DEPLOY_PLIST="/Library/LaunchDaemons/com.caddyserver.caddy.plist"
 DEPLOY_MEDIA_SERVER="/usr/local/bin/media-server.py"
 DEPLOY_MEDIA_PLIST="/Library/LaunchDaemons/com.${HOSTNAME_LOWER}.media-server.plist"
@@ -124,6 +125,17 @@ else
   exit 1
 fi
 
+# Deploy caddy-health.sh
+echo "Deploying caddy-health.sh..."
+if [[ -f "${TEMPLATE_DIR}/caddy-health.sh" ]]; then
+  substitute_template "${TEMPLATE_DIR}/caddy-health.sh" "${DEPLOY_HEALTH}"
+  chmod +x "${DEPLOY_HEALTH}"
+  echo "✓ Copied caddy-health.sh to ${DEPLOY_HEALTH}"
+else
+  echo "❌ No caddy-health.sh found in ${TEMPLATE_DIR}"
+  exit 1
+fi
+
 # Install LaunchDaemon plist
 echo "Installing LaunchDaemon plist..."
 PLIST_SOURCE="${TEMPLATE_DIR}/com.caddyserver.caddy.plist"
@@ -193,6 +205,7 @@ echo "  Server URL: https://${HOSTNAME}.local"
 echo "  Web root: ${DEPLOY_WEB_ROOT}"
 echo "  Config: ${DEPLOY_CONFIG_DIR}/Caddyfile"
 echo "  Wrapper: ${DEPLOY_WRAPPER}"
+echo "  Health check: ${DEPLOY_HEALTH}"
 echo "  Media server: ${DEPLOY_MEDIA_SERVER}"
 echo "  Logs: ${DEPLOY_LOG_DIR}/"
 echo ""
@@ -200,7 +213,7 @@ echo "Commands:"
 echo "  Start:   sudo launchctl bootstrap system ${DEPLOY_PLIST}"
 echo "  Restart: sudo launchctl kickstart -k system/com.caddyserver.caddy"
 echo "  Stop:    sudo launchctl bootout system/com.caddyserver.caddy"
-echo "  Health:  ./caddy-health.sh"
+echo "  Health:  ${DEPLOY_HEALTH}"
 echo ""
 echo "Certificate installation:"
 echo "  Download: https://${HOSTNAME}.local/caddy-root-ca.crt"

--- a/docs/apps/caddy-README.md
+++ b/docs/apps/caddy-README.md
@@ -29,7 +29,7 @@ sudo launchctl kickstart -k system/com.caddyserver.caddy
 sudo launchctl bootout system/com.caddyserver.caddy
 
 # Health check all endpoints
-./caddy-health.sh
+caddy-health.sh
 
 # Generate a bcrypt password hash for basic_auth
 caddy hash-password
@@ -69,7 +69,7 @@ The `(common_config)` snippet contains all shared logic:
 - `app-setup/caddy-setup.sh` — Full deployment script: copies web assets, Caddyfile, wrapper script, and LaunchDaemon plists to their deployed locations, then validates config
 - `app-setup/templates/Caddyfile` — Production config (the main file you'll edit)
 - `app-setup/templates/caddy-wrapper.sh` — Reads `CF_API_TOKEN` from System keychain, exports it, then `exec`s Caddy. Deployed to `/usr/local/bin/caddy-wrapper.sh`
-- `app-setup/templates/caddy-health.sh` — Tests landing page, proxies, certs, and process status
+- `app-setup/templates/caddy-health.sh` — Tests landing page, proxies, certs, and process status. Deployed to `/usr/local/bin/caddy-health.sh`
 - `app-setup/templates/media-server.py` — Python HTTP file server for NFS media volume (binds to `127.0.0.1:9880`)
 - `app-setup/templates/www/` — Static web root (dashboard `index.html`, favicons, manifest)
 - `app-setup/templates/com.caddyserver.caddy.plist` — Caddy LaunchDaemon
@@ -83,6 +83,7 @@ Files are not served directly from the repo. `caddy-setup.sh` deploys everything
 - `www/*` → `/usr/local/var/www/` (web root)
 - `Caddyfile` → `/Users/operator/.config/caddy/Caddyfile` (runtime config)
 - `caddy-wrapper.sh` → `/usr/local/bin/caddy-wrapper.sh` (token injection wrapper)
+- `caddy-health.sh` → `/usr/local/bin/caddy-health.sh` (health check script)
 - `media-server.py` → `/usr/local/bin/media-server.py` (NFS media file server)
 - `LaunchDaemons/*.plist` → `/Library/LaunchDaemons/` (system services)
 
@@ -206,7 +207,7 @@ The `caddy-dns/cloudflare` module uses certmagic internally. certmagic has two s
 **Critical:** There are two env var syntaxes in Caddy and they are NOT interchangeable in all contexts.
 
 | Syntax | Processed by | When | Result in JSON config |
-|--------|-------------|------|-----------------------|
+| -------- | ------------- | ------ | ----------------------- |
 | `{$CF_API_TOKEN}` | Caddyfile adapter | At parse time | Actual token value baked in |
 | `{env.CF_API_TOKEN}` | Caddy runtime | At request time (HTTP handlers) | Literal string passed to module |
 


### PR DESCRIPTION
## Summary
- `caddy-health.sh` was never included in `caddy-setup.sh`'s deployment step, so it shipped with literal `__OPERATOR_USERNAME__` placeholders (lines 110 and 131) instead of the resolved operator username.
- This caused Test 8 (Configuration) in the health check to always report a false negative, and the displayed error-log path was wrong.
- Adds `caddy-health.sh` to the same `substitute_template` + deploy flow already used for `caddy-wrapper.sh`, installing it to `/usr/local/bin/caddy-health.sh`.
- Updates `caddy-setup.sh`'s summary output and `docs/apps/caddy-README.md` to reflect the new deployed path.

Fixes #107.

## Test plan
- [x] `shellcheck -S info app-setup/caddy-setup.sh` — clean
- [x] `bash -n app-setup/caddy-setup.sh` — syntax OK
- [x] Simulated `substitute_template` against `caddy-health.sh` locally — placeholders resolve correctly (`/Users/operator/.config/caddy/Caddyfile`, `/Users/operator/.local/state/caddy/caddy-error.log`)
- [x] `./run_tests.sh` — full unit + integration suite passes (no existing tests reference caddy scripts)
- [x] Local pre-commit and pre-push review hooks (code-reviewer, adversarial-reviewer, full-diff review, codebase review) — all PASS

https://claude.ai/code/session_0143Nf4sXqnTp2Kx3LNbMvBA