### PR TITLE
fix(transmission-done): use dynamic Plex library section IDs instead of hardcoded 1/2

### DIFF
--- a/app-setup/templates/config.yml.template
+++ b/app-setup/templates/config.yml.template
@@ -6,6 +6,8 @@ plex:
   server: http://localhost:32400
   token: __PLEX_TOKEN__
   media_path: __PLEX_MEDIA_PATH__
+  movie_section_id: __PLEX_MOVIE_SECTION_ID__
+  tv_section_id: __PLEX_TV_SECTION_ID__
 logging:
   file: .local/state/transmission-processing.log
   max_size: 10485760

--- a/app-setup/templates/transmission-done.sh
+++ b/app-setup/templates/transmission-done.sh
@@ -106,6 +106,11 @@ readonly FILEBOT="${HOMEBREW_PREFIX}/bin/filebot"
 PLEX_SERVER=""
 PLEX_TOKEN=""
 PLEX_MEDIA_PATH="${PLEX_MEDIA_PATH:-}"
+# Legacy hardcoded fallbacks retained for configs written before section IDs
+# were discovered/stored (see #110). New installs get real values from
+# config.yml via read_config().
+PLEX_MOVIE_SECTION_ID="${PLEX_MOVIE_SECTION_ID:-1}"
+PLEX_TV_SECTION_ID="${PLEX_TV_SECTION_ID:-2}"
 LOG_FILE=""
 MAX_LOG_SIZE=0
 
@@ -181,6 +186,19 @@ read_config() {
   if ((${#missing_values[@]} > 0)); then
     printf 'Error: Missing required config values: %s\n' "${missing_values[*]}" >&2
     return 1
+  fi
+
+  # Library section IDs are optional: older configs won't have them, and
+  # yq prints the literal string "null" for a missing/empty scalar key.
+  # Fall back to the pre-existing hardcoded defaults (1/2) in that case.
+  local movie_section_id tv_section_id
+  movie_section_id=$("${YQ}" eval '.plex.movie_section_id' "${config_file}")
+  tv_section_id=$("${YQ}" eval '.plex.tv_section_id' "${config_file}")
+  if [[ -n "${movie_section_id}" ]] && [[ "${movie_section_id}" != "null" ]]; then
+    PLEX_MOVIE_SECTION_ID="${movie_section_id}"
+  fi
+  if [[ -n "${tv_section_id}" ]] && [[ "${tv_section_id}" != "null" ]]; then
+    PLEX_TV_SECTION_ID="${tv_section_id}"
   fi
 
   local log_path
@@ -354,8 +372,8 @@ trigger_plex_scan() {
   local section_id
 
   case "${section_type}" in
-    "show") section_id="2" ;;
-    "movie") section_id="1" ;;
+    "show") section_id="${PLEX_TV_SECTION_ID}" ;;
+    "movie") section_id="${PLEX_MOVIE_SECTION_ID}" ;;
     *)
       log "Error: Unknown media type for Plex scan: ${section_type}"
       return 1

--- a/app-setup/templates/transmission-done.sh
+++ b/app-setup/templates/transmission-done.sh
@@ -188,9 +188,13 @@ read_config() {
     return 1
   fi
 
-  # Library section IDs are optional: older configs won't have them, and
-  # yq prints the literal string "null" for a missing/empty scalar key.
-  # Fall back to the pre-existing hardcoded defaults (1/2) in that case.
+  # Library section IDs are optional: older configs won't have them at all
+  # (yq prints the literal string "null" for a missing key), and configs
+  # written by an installer run where discovery failed will have a blank
+  # scalar (yq prints "" -- empty string -- for that case, not "null").
+  # The `-n` check handles the blank-scalar case; the `!= "null"` check
+  # handles the missing-key case. Both fall back to the pre-existing
+  # hardcoded defaults (1/2) set at script scope above.
   local movie_section_id tv_section_id
   movie_section_id=$("${YQ}" eval '.plex.movie_section_id' "${config_file}")
   tv_section_id=$("${YQ}" eval '.plex.tv_section_id' "${config_file}")

--- a/app-setup/transmission-filebot-setup.sh
+++ b/app-setup/transmission-filebot-setup.sh
@@ -433,6 +433,52 @@ find_common_root() {
   fi
 }
 
+get_plex_section_ids() {
+  local plex_server="$1"
+  local token="$2"
+
+  local response
+  if ! response=$(curl -sf -m 10 -H "X-Plex-Token: ${token}" "${plex_server}/library/sections" 2>&1); then
+    printf 'Warning: Could not retrieve library sections for scan IDs\n' >&2
+    return 1
+  fi
+
+  local section_count
+  if ! section_count=$(echo "${response}" | xmlstarlet sel -t -v "count(//Directory)" 2>/dev/null); then
+    printf 'Warning: Could not parse library sections XML for scan IDs\n' >&2
+    return 1
+  fi
+
+  if [[ -z "${section_count}" ]] || [[ "${section_count}" -eq 0 ]]; then
+    printf 'Warning: No library sections found for scan IDs\n' >&2
+    return 1
+  fi
+
+  local movie_section_id=""
+  local tv_section_id=""
+
+  local i
+  for ((i = 1; i <= section_count; i++)); do
+    local id type
+    id=$(echo "${response}" | xmlstarlet sel -t -v "//Directory[${i}]/@key" 2>/dev/null)
+    type=$(echo "${response}" | xmlstarlet sel -t -v "//Directory[${i}]/@type" 2>/dev/null)
+
+    [[ -z "${id}" ]] && continue
+
+    # Use the first section found of each type. Plex's library section
+    # "type" attribute is "movie" for movie libraries and "show" for TV.
+    if [[ "${type}" == "movie" ]] && [[ -z "${movie_section_id}" ]]; then
+      movie_section_id="${id}"
+    elif [[ "${type}" == "show" ]] && [[ -z "${tv_section_id}" ]]; then
+      tv_section_id="${id}"
+    fi
+  done
+
+  # Return both values (space-separated) for the caller to split.
+  printf '%s %s\n' "${movie_section_id}" "${tv_section_id}"
+  return 0
+}
+
 get_media_path() {
   local plex_server="$1"
   local token="$2"
@@ -573,6 +619,8 @@ write_config() {
   local plex_server="$1"
   local plex_token="$2"
   local media_path="$3"
+  local movie_section_id="${4:-}"
+  local tv_section_id="${5:-}"
 
   # Create config directory if it doesn't exist
   if [[ ! -d "${USER_CONFIG_DIR}" ]]; then
@@ -600,6 +648,8 @@ plex:
   server: ${plex_server}
   token: ${plex_token}
   media_path: ${media_path}
+  movie_section_id: ${movie_section_id}
+  tv_section_id: ${tv_section_id}
 logging:
   file: .local/state/transmission-processing.log
   max_size: 10485760  # 10MB
@@ -713,8 +763,26 @@ main() {
   local media_path
   media_path=$(get_media_path "${plex_server}" "${token}") || exit 1
 
+  # Discover movie/TV library section IDs for runtime Plex scan triggers.
+  # Non-fatal if this fails — transmission-done.sh falls back to legacy
+  # hardcoded IDs (1/2) when these are blank.
+  local movie_section_id=""
+  local tv_section_id=""
+  local section_ids
+  if section_ids=$(get_plex_section_ids "${plex_server}" "${token}"); then
+    read -r movie_section_id tv_section_id <<<"${section_ids}"
+  fi
+
+  if [[ -n "${movie_section_id}" ]] || [[ -n "${tv_section_id}" ]]; then
+    printf '\nDetected library section IDs: movie=%s tv=%s\n' \
+      "${movie_section_id:-none}" "${tv_section_id:-none}" >&2
+  else
+    printf '\nWarning: Could not determine library section IDs automatically.\n' >&2
+    printf 'transmission-done will fall back to legacy hardcoded section IDs (movie=1, tv=2).\n' >&2
+  fi
+
   # Write configuration file
-  if ! write_config "${plex_server}" "${token}" "${media_path}"; then
+  if ! write_config "${plex_server}" "${token}" "${media_path}" "${movie_section_id}" "${tv_section_id}"; then
     printf 'Error: Failed to write configuration\n' >&2
     exit 1
   fi

--- a/app-setup/transmission-filebot-setup.sh
+++ b/app-setup/transmission-filebot-setup.sh
@@ -474,8 +474,12 @@ get_plex_section_ids() {
     fi
   done
 
-  # Return both values (space-separated) for the caller to split.
-  printf '%s %s\n' "${movie_section_id}" "${tv_section_id}"
+  # Return both values as key=value lines (Plex section IDs are always
+  # small integers, but this format avoids any ambiguity from
+  # whitespace-splitting a single line, and is easy for the caller to
+  # parse without relying on positional field order).
+  printf 'movie_section_id=%s\n' "${movie_section_id}"
+  printf 'tv_section_id=%s\n' "${tv_section_id}"
   return 0
 }
 
@@ -770,7 +774,13 @@ main() {
   local tv_section_id=""
   local section_ids
   if section_ids=$(get_plex_section_ids "${plex_server}" "${token}"); then
-    read -r movie_section_id tv_section_id <<<"${section_ids}"
+    while IFS='=' read -r key value; do
+      case "${key}" in
+        movie_section_id) movie_section_id="${value}" ;;
+        tv_section_id) tv_section_id="${value}" ;;
+        *) ;;
+      esac
+    done <<<"${section_ids}"
   fi
 
   if [[ -n "${movie_section_id}" ]] || [[ -n "${tv_section_id}" ]]; then

--- a/tests/transmission-filebot/unit/test_plex_api.bats
+++ b/tests/transmission-filebot/unit/test_plex_api.bats
@@ -167,3 +167,93 @@ load ../test_helper
   run cat "${LOG_FILE}"
   assert_output_contains "/custom/endpoint" "${output}"
 }
+
+# --- Dynamic library section ID tests (#110) ---
+# These verify trigger_plex_scan() uses PLEX_MOVIE_SECTION_ID /
+# PLEX_TV_SECTION_ID when set (e.g. via read_config() from config.yml),
+# rather than the legacy hardcoded 1/2. Defaults are covered by the
+# "uses section ID 1/2" tests above, which rely on the fallback values
+# set at script scope when config doesn't provide overrides.
+
+@test "trigger_plex_scan: uses configured movie section ID instead of hardcoded default" {
+  export TEST_MODE=true
+  export LOG_FILE="${TEST_TEMP_DIR}/test.log"
+  export PLEX_MOVIE_SECTION_ID=7
+  : >"${LOG_FILE}"
+
+  trigger_plex_scan "movie"
+
+  run cat "${LOG_FILE}"
+  assert_output_contains "/library/sections/7/refresh" "${output}"
+  [[ "${output}" != *"/library/sections/1/refresh"* ]] || return 1
+}
+
+@test "trigger_plex_scan: uses configured tv section ID instead of hardcoded default" {
+  export TEST_MODE=true
+  export LOG_FILE="${TEST_TEMP_DIR}/test.log"
+  export PLEX_TV_SECTION_ID=9
+  : >"${LOG_FILE}"
+
+  trigger_plex_scan "show"
+
+  run cat "${LOG_FILE}"
+  assert_output_contains "/library/sections/9/refresh" "${output}"
+  [[ "${output}" != *"/library/sections/2/refresh"* ]] || return 1
+}
+
+@test "trigger_plex_scan: falls back to legacy hardcoded ID when config value is unset" {
+  export TEST_MODE=true
+  export LOG_FILE="${TEST_TEMP_DIR}/test.log"
+  # PLEX_MOVIE_SECTION_ID defaults to "1" at script scope (see
+  # `PLEX_MOVIE_SECTION_ID="${PLEX_MOVIE_SECTION_ID:-1}"` near the top of
+  # transmission-done.sh) when config.yml doesn't provide an override.
+  : >"${LOG_FILE}"
+
+  trigger_plex_scan "movie"
+
+  run cat "${LOG_FILE}"
+  assert_output_contains "/library/sections/1/refresh" "${output}"
+}
+
+@test "read_config: parses movie_section_id and tv_section_id via yq the same way as other plex.* fields" {
+  # read_config() reads from LOCAL_CONFIG/USER_CONFIG, both readonly paths
+  # fixed at script-source time, so it can't be redirected to a per-test
+  # fixture here. Instead, verify the same yq parsing expression read_config
+  # uses behaves as expected against a standalone fixture — this is the
+  # same technique read_config relies on for every other plex.* field.
+  local config_file="${TEST_TEMP_DIR}/config.yml"
+  cat >"${config_file}" <<EOF
+---
+version: 1.0
+plex:
+  server: http://localhost:32400
+  token: test_token
+  media_path: ${PLEX_MEDIA_PATH}
+  movie_section_id: 5
+  tv_section_id: 6
+EOF
+
+  run "${YQ}" eval '.plex.movie_section_id' "${config_file}"
+  assert_success
+  assert_equal "5" "${output}"
+
+  run "${YQ}" eval '.plex.tv_section_id' "${config_file}"
+  assert_success
+  assert_equal "6" "${output}"
+}
+
+@test "read_config: yq returns 'null' string for missing section ID keys (read_config's fallback trigger)" {
+  local config_file="${TEST_TEMP_DIR}/config.yml"
+  cat >"${config_file}" <<EOF
+---
+version: 1.0
+plex:
+  server: http://localhost:32400
+  token: test_token
+  media_path: ${PLEX_MEDIA_PATH}
+EOF
+
+  run "${YQ}" eval '.plex.movie_section_id' "${config_file}"
+  assert_success
+  assert_equal "null" "${output}"
+}

--- a/tests/transmission-filebot/unit/test_plex_api.bats
+++ b/tests/transmission-filebot/unit/test_plex_api.bats
@@ -257,3 +257,27 @@ EOF
   assert_success
   assert_equal "null" "${output}"
 }
+
+@test "read_config: yq returns empty string (not 'null') for a blank scalar section ID -- both are handled by the same guard" {
+  # Covers the case where transmission-filebot-setup.sh's write_config()
+  # wrote the key but discovery found no value (movie_section_id: <blank>),
+  # as opposed to the key being absent entirely (previous test, yq -> "null").
+  # read_config()'s guard is `[[ -n "$v" ]] && [[ "$v" != "null" ]]`, which
+  # must reject both an empty string AND the literal "null".
+  local config_file="${TEST_TEMP_DIR}/config.yml"
+  cat >"${config_file}" <<EOF
+---
+version: 1.0
+plex:
+  server: http://localhost:32400
+  token: test_token
+  media_path: ${PLEX_MEDIA_PATH}
+  movie_section_id:
+  tv_section_id:
+EOF
+
+  run "${YQ}" eval '.plex.movie_section_id' "${config_file}"
+  assert_success
+  assert_equal "" "${output}"
+  [[ -z "${output}" ]] || return 1
+}

--- a/tests/transmission-filebot/unit/test_plex_api.bats
+++ b/tests/transmission-filebot/unit/test_plex_api.bats
@@ -279,5 +279,4 @@ EOF
   run "${YQ}" eval '.plex.movie_section_id' "${config_file}"
   assert_success
   assert_equal "" "${output}"
-  [[ -z "${output}" ]] || return 1
 }


### PR DESCRIPTION
## Summary
- `trigger_plex_scan()` in `transmission-done.sh` hardcoded Plex library section IDs (1 for movies, 2 for shows). Plex assigns these based on library creation order, so this breaks for any setup that doesn't match.
- `transmission-filebot-setup.sh` now discovers section IDs via `/library/sections` (reusing the same xmlstarlet parsing approach as the existing media-path discovery) and stores them in `config.yml` as `plex.movie_section_id` / `plex.tv_section_id`.
- `transmission-done.sh`'s `read_config()` reads the new fields; `trigger_plex_scan()` uses them instead of the hardcoded literals.
- Non-fatal fallback preserved throughout: if discovery fails, or an older config doesn't have the new fields, `PLEX_MOVIE_SECTION_ID`/`PLEX_TV_SECTION_ID` default to the legacy `1`/`2` at script scope — existing installs keep working unchanged.

Fixes #110 (flagged by sentry[bot] on PR #108, HIGH severity)

## Test plan
- [x] `shellcheck -S info` clean on all modified files
- [x] `./run_tests.sh` — all unit + integration tests pass
- [x] `bats tests/transmission-filebot/unit/test_plex_api.bats` — 21/21 pass, including new tests for the configured-ID override, the legacy-fallback path, and both yq null/blank-scalar cases `read_config()`'s guard must reject
- [x] Verified `get_plex_section_ids()`'s XML-parsing logic manually against a sample multi-library Plex `/library/sections` response
- [x] Local pre-commit and pre-push review hooks passed (code-reviewer, adversarial-reviewer, full-diff review, codebase review) — one pre-push BLOCKING finding (blank-scalar config value bypassing the null-fallback guard) was investigated, empirically verified to be a false positive (the existing `-n` non-empty check already rejects blank scalars), and the guard's comment + test coverage were expanded to make that explicit for future reviewers

## Known follow-ups (tracked separately, non-blocking)
- #153/#155: `get_plex_section_ids()` itself has no unit tests (requires a live Plex server or a curl mock harness not currently used elsewhere in this script)
- #154: `config.yml.template` and the `write_config()` heredoc are two separate schema definitions that could drift (pre-existing pattern, not introduced here)
- #156: blank section-id values in `config.yml` have trailing whitespace after the `:` (cosmetic, correctly handled by the parser)

https://claude.ai/code/session_019yrvtEbtQxBxDmZ4Fu9GrU