### PR TITLE
fix(logrotate): add rclone glob, fix operator-first-login dot/hyphen mismatch

### DIFF
--- a/config/logrotate.conf
+++ b/config/logrotate.conf
@@ -31,8 +31,9 @@ include /opt/homebrew/etc/logrotate.d
 /Users/*/.local/state/*-mount.log
 /Users/*/.local/state/com.*.mount-nas-media.log
 /Users/*/.local/state/*-plex-launchagent.log
-/Users/*/.local/state/com.*-operator-first-login.log
+/Users/*/.local/state/com.*.operator-first-login.log
 /Users/*/.local/state/msmtp.log
+/Users/*/.local/state/*-rclone.log
 /Users/*/.local/state/plex-watchdog.log
 /Users/*/.local/state/*-podman-vm-stdout.log
 /Users/*/.local/state/*-podman-vm-stderr.log

--- a/tests/logrotate-globs.bats
+++ b/tests/logrotate-globs.bats
@@ -83,6 +83,18 @@ considers_file() {
   considers_file "${f}"
 }
 
+@test "matches *-rclone.log (#95: tilsit-rclone was not rotating, no pattern covered it)" {
+  local f="${STATE_DIR}/tilsit-rclone.log"
+  touch "${f}"
+  considers_file "${f}"
+}
+
+@test "matches com.<host>.operator-first-login.log (dot-form label, #95)" {
+  local f="${STATE_DIR}/com.tilsit.operator-first-login.log"
+  touch "${f}"
+  considers_file "${f}"
+}
+
 # ---------------------------------------------------------------------------
 # Regression guard: the old hyphen-form glob would miss the dot-form label.
 # This is a local sanity check on glob semantics, not a test of our config.
@@ -99,6 +111,24 @@ ${STATE_DIR}/com.*-mount-nas-media.log {
 }
 EOF
   local f="${STATE_DIR}/com.tilsit.mount-nas-media.log"
+  touch "${f}"
+  run sh -c "logrotate -d '${bad_conf}' 2>&1 | grep -Fq 'considering log ${f}'"
+  [ "${status}" -ne 0 ]
+}
+
+@test "regression: com.*-operator-first-login.log does NOT match com.tilsit.operator-first-login.log (#95)" {
+  # The pattern this repo shipped before #95 (com.*-operator-first-login.log,
+  # hyphen before "operator") never matched the actual LaunchAgent-produced
+  # filename (com.<host>.operator-first-login.log, dot before "operator") --
+  # the same class of bug already fixed once for mount-nas-media.log.
+  local bad_conf="${TEST_TMPDIR}/bad.conf"
+  cat >"${bad_conf}" <<EOF
+${STATE_DIR}/com.*-operator-first-login.log {
+    weekly
+    missingok
+}
+EOF
+  local f="${STATE_DIR}/com.tilsit.operator-first-login.log"
   touch "${f}"
   run sh -c "logrotate -d '${bad_conf}' 2>&1 | grep -Fq 'considering log ${f}'"
   [ "${status}" -ne 0 ]


### PR DESCRIPTION
## Summary
- `tilsit-rclone.log` (5.5M and growing) was not rotating because no pattern in `config/logrotate.conf` matched `*-rclone.log` at all — confirmed `start-rclone.sh` writes to `${LOG_DIR}/${SERVER_NAME_LOWER}-rclone.log` and nothing covered it.
- While auditing every `LOG_FILE` definition in the repo against the existing glob list, found a second pre-existing match failure of the same class this repo already fixed once for `mount-nas-media.log`: the operator-first-login LaunchAgent writes `com.<host>.operator-first-login.log` (dot before "operator"), but the config pattern was `com.*-operator-first-login.log` (hyphen before "operator") — confirmed with `logrotate -d` that the hyphen-form pattern never actually expanded against the real filename.

Fixes #95

## Test plan
- [x] `shellcheck -S info` clean (config file isn't a shell script; `tests/logrotate-globs.bats` is clean)
- [x] `bats tests/logrotate-globs.bats` — 10/10 pass (2 new positive-match tests + 1 new regression test, plus the 7 pre-existing tests)
- [x] Manually verified with `logrotate -d` against real-shaped fixture filenames before and after the fix
- [x] Local pre-commit and pre-push review hooks passed clean (code-reviewer, adversarial-reviewer, full-diff review, codebase review) — no findings

## Note on scope
Two other `LOG_FILE` definitions in the repo (`pending-move-cleanup.sh`, `transmission-trigger-watcher.sh`) were checked during the audit but have their own built-in `rotate_log()` self-rotation, so they're out of scope for this issue, which is specifically about the missing rclone coverage.

https://claude.ai/code/session_019yrvtEbtQxBxDmZ4Fu9GrU