### PR TITLE
fix: resolve four quick-win issues from triage pass

### DIFF
--- a/app-setup/templates/config.yml.template
+++ b/app-setup/templates/config.yml.template
@@ -1,3 +1,6 @@
+# NOTE: This template is for reference/documentation only. The authoritative
+# generator is write_config() in app-setup/transmission-filebot-setup.sh —
+# update that function first, then mirror the change here to keep them in sync.
 ---
 version: 1.0
 paths:

--- a/app-setup/transmission-filebot-setup.sh
+++ b/app-setup/transmission-filebot-setup.sh
@@ -640,6 +640,17 @@ write_config() {
     cp "${USER_CONFIG}" "${backup}"
   fi
 
+  # Build optional section-id lines only when a value is present, to avoid
+  # emitting trailing whitespace after the colon (e.g. "movie_section_id: ")
+  # when discovery fails and the variable is empty.
+  local movie_section_line="" tv_section_line=""
+  if [[ -n "${movie_section_id}" ]]; then
+    movie_section_line="  movie_section_id: ${movie_section_id}"$'\n'
+  fi
+  if [[ -n "${tv_section_id}" ]]; then
+    tv_section_line="  tv_section_id: ${tv_section_id}"$'\n'
+  fi
+
   # Write new config (mode 600 — contains Plex auth token)
   printf 'Writing config to: %s\n' "${USER_CONFIG}" >&2
   (
@@ -652,9 +663,7 @@ plex:
   server: ${plex_server}
   token: ${plex_token}
   media_path: ${media_path}
-  movie_section_id: ${movie_section_id}
-  tv_section_id: ${tv_section_id}
-logging:
+${movie_section_line}${tv_section_line}logging:
   file: .local/state/transmission-processing.log
   max_size: 10485760  # 10MB
 EOF

--- a/tests/podman-machine-start.bats
+++ b/tests/podman-machine-start.bats
@@ -138,16 +138,19 @@ write_podman_mock() {
 #!/usr/bin/env bash
 echo "$*" >>"${CALLS_FILE}"
 
-case "$1 $2" in
-  "machine inspect")
+# Dispatch on the full argument list (not just "$1 $2") so callers that pass
+# extra flags -- e.g. `machine inspect transmission-vm --format '{{.State}}'`
+# -- are matched by pattern rather than having those flags silently ignored.
+case "$*" in
+  "machine inspect"*)
     cat "${MACHINE_STATE_FILE}"
     exit 0
     ;;
-  "machine start")
+  "machine start"*)
     echo "running" >"${MACHINE_STATE_FILE}"
     exit 0
     ;;
-  "machine stop")
+  "machine stop"*)
     echo "stopped" >"${MACHINE_STATE_FILE}"
     exit 0
     ;;

--- a/tests/transmission-filebot/unit/test_file_safety.bats
+++ b/tests/transmission-filebot/unit/test_file_safety.bats
@@ -136,7 +136,7 @@ stub_df() {
 }
 
 @test "check_disk_space: succeeds when df reports sufficient space" {
-  stub_df 'printf "Filesystem 512-blocks Used Available Capacity Mounted on\n"
+  stub_df 'printf "Filesystem 1024-blocks Used Available Capacity Mounted on\n"
 printf "/dev/disk1  976490568 1000 976489568   1%% %s\n" "'"${PLEX_MEDIA_PATH}"'"'
 
   run check_disk_space
@@ -145,7 +145,7 @@ printf "/dev/disk1  976490568 1000 976489568   1%% %s\n" "'"${PLEX_MEDIA_PATH}"'
 }
 
 @test "check_disk_space: fails and logs error when df reports insufficient space" {
-  stub_df 'printf "Filesystem 512-blocks Used Available Capacity Mounted on\n"
+  stub_df 'printf "Filesystem 1024-blocks Used Available Capacity Mounted on\n"
 printf "/dev/disk1  976490568 976489568 100   99%% %s\n" "'"${PLEX_MEDIA_PATH}"'"'
 
   run check_disk_space


### PR DESCRIPTION
## Summary
- `write_config()` omits `movie_section_id`/`tv_section_id` lines entirely when discovery yields no value, instead of leaving trailing whitespace after the colon (Fixes #156). `read_config()`'s existing guard (`[[ -n "$v" ]] && [[ "$v" != "null" ]]`) already treats an absent key the same as a blank one — verified against the covering bats tests.
- `config.yml.template` now has a header comment noting it's reference-only documentation and that `write_config()` in `transmission-filebot-setup.sh` is the source of truth (Fixes #154).
- `test_file_safety.bats`'s `stub_df` fixture now prints `1024-blocks` (the actual POSIX `df -P` header) instead of `512-blocks`. `check_disk_space()` parses by column position via `awk`, so this is a label-only fix with no logic impact (Fixes #151).
- `podman-machine-start.bats`'s podman mock now dispatches on the full `"$*"` instead of just `"$1 $2"`, so `--format` and other trailing flags are no longer silently swallowed by the mock (Fixes #150).

## Test plan
- [x] Full bats suite via `./run_tests.sh` (unit + integration under `tests/transmission-filebot/`) — all passing
- [x] `bats tests/podman-machine-start.bats tests/plex-watchdog.bats tests/cloudflare-ddns.bats tests/logrotate-globs.bats` — all passing
- [x] `shellcheck` on modified shell script — clean
- [x] Manual heredoc simulation confirming no trailing whitespace and correct conditional-line omission for `write_config()`

Fixes #150, Fixes #151, Fixes #154, Fixes #156

https://claude.ai/code/session_01BmuTHyHEJv26WZkyTWHZDp