### PR TITLE
fix(transmission-filebot): extract get_plex_section_ids() via marker comments

### DIFF
--- a/app-setup/transmission-filebot-setup.sh
+++ b/app-setup/transmission-filebot-setup.sh
@@ -433,6 +433,11 @@ find_common_root() {
   fi
 }
 
+# BEGIN get_plex_section_ids
+# Marker comments above/below this function are relied on by
+# tests/transmission-filebot/unit/test_plex_section_ids.bats to extract the
+# function body for isolated sourcing. Keep them adjacent to the function if
+# it is ever moved, and update the test's awk pattern if this changes.
 get_plex_section_ids() {
   local plex_server="$1"
   local token="$2"
@@ -482,6 +487,7 @@ get_plex_section_ids() {
   printf 'tv_section_id=%s\n' "${tv_section_id}"
   return 0
 }
+# END get_plex_section_ids
 
 get_media_path() {
   local plex_server="$1"

--- a/tests/transmission-filebot/unit/test_plex_section_ids.bats
+++ b/tests/transmission-filebot/unit/test_plex_section_ids.bats
@@ -38,9 +38,14 @@ setup() {
   export TEST_TMPDIR
 
   # Extract only the get_plex_section_ids() function definition so sourcing
-  # it does not also run main() at the bottom of the real script.
+  # it does not also run main() at the bottom of the real script. Extraction
+  # is keyed on the "# BEGIN/END get_plex_section_ids" marker comments
+  # surrounding the function in the source script (rather than matching its
+  # exact signature), so reformatting the function body or brace style does
+  # not silently break this test -- see the markers in
+  # app-setup/transmission-filebot-setup.sh if this ever needs updating.
   local func_file="${TEST_TMPDIR}/get_plex_section_ids.sh"
-  awk '/^get_plex_section_ids\(\) \{$/{flag=1} flag{print} flag && /^}$/{exit}' \
+  awk '/^# BEGIN get_plex_section_ids$/{flag=1; next} /^# END get_plex_section_ids$/{exit} flag' \
     "${SETUP_SCRIPT}" >"${func_file}"
 
   if [[ ! -s "${func_file}" ]]; then


### PR DESCRIPTION
## Summary
- Replaces the exact-signature `awk` match used to extract `get_plex_section_ids()` for isolated test sourcing with `# BEGIN/END get_plex_section_ids` marker comments, so a future reformat (brace style, `function` keyword, etc.) doesn't silently break test extraction (#161).
- Closes #162 as already fixed — the `xmlstarlet` skip guard it requested was added in 62adbdb (PR #163) before the issue was filed against a stale review snapshot.

## Test plan
- [x] `bats tests/transmission-filebot/unit/test_plex_section_ids.bats` — 8/8 pass
- [x] Full BATS suite (`plex-watchdog.bats`, `cloudflare-ddns.bats`, `tests/transmission-filebot/**/*.bats`) — 207/207 pass
- [x] `shellcheck -S info` clean on both changed files
- [x] `shfmt -d -i 2 -ci -bn` clean on both changed files
- [x] Pre-commit and pre-push automated reviews (code-reviewer, adversarial-reviewer, codebase review) all PASS

Closes #161

https://claude.ai/code/session_01YRmoLTYXtd1mR2WYhxZ9Z1