### PR TITLE
feat(pia): add PF region probe, port guard, and VPN runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,20 @@ replaces it, System keychain token reuse (same entry Caddy reads), public-IP
 provider fallback chain, change-detection vs heartbeat log cadence, Cloudflare
 API error modes, and the `TEST_RUNNER` hook that lets BATS mock network calls.
 
+### PIA VPN (credentials, port forwarding, region selection)
+
+**Files**: `app-setup/podman-transmission-setup.sh`,
+`app-setup/templates/pia-pf-probe.sh`,
+`app-setup/templates/pia-port-guard.sh`, `tests/pia-port-guard.bats`
+
+**Documentation**: `docs/apps/pia-vpn-README.md`
+
+**Covers**: PIA credential chain (1Password → keychain → .env → container) and
+the password rotation procedure, next-generation port-forwarding flow, why
+PIA's `port_forward` region flag cannot be trusted, the upstream
+`update-port.sh` bug that zeroes Transmission's listen port on PF failure, and
+diagnosing tunnel-vs-port-forwarding failures
+
 ### Transmission-FileBot (media processing pipeline)
 
 **Files**: `app-setup/templates/transmission-done.sh`,

--- a/app-setup/templates/pia-pf-probe.sh
+++ b/app-setup/templates/pia-pf-probe.sh
@@ -138,7 +138,10 @@ probe_region() {
   # --cap-add NET_ADMIN and /dev/net/tun are what OpenVPN needs to build the
   # tunnel. No ports are published: the probe never needs inbound access, and
   # publishing 9091 would collide with the live container.
-  if ! podman run -d --rm \
+  # No --rm: it races with the explicit cleanup below, and a SIGKILLed script
+  # would leave the container behind either way. cleanup_probe_container plus
+  # the EXIT trap is the single cleanup path.
+  if ! podman run -d \
     --name "${PROBE_CONTAINER}" \
     --cap-add NET_ADMIN \
     --device /dev/net/tun \

--- a/app-setup/templates/pia-pf-probe.sh
+++ b/app-setup/templates/pia-pf-probe.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+#
+# pia-pf-probe.sh — probe PIA regions for working port forwarding
+#
+# PIA's server list advertises a per-region `port_forward` boolean, but that
+# flag is not reliable: the Panama region advertises port_forward=true while
+# serving nothing on the PF API port (verified 2026-08-23, issue #159). The
+# only trustworthy signal is establishing a tunnel and asking the PF API for a
+# real port.
+#
+# This script connects to each candidate region in turn using a throwaway
+# OpenVPN process, calls PIA's next-generation getSignature endpoint, and
+# records whether a usable port came back. Results are written as CSV so the
+# region-selection work in issue #159 has real data to rank against.
+#
+# The probe runs in its own container and never touches the live
+# transmission-vpn container, so downloads in progress are unaffected.
+#
+# Usage:
+#   ./pia-pf-probe.sh                     # probe the default shortlist
+#   ./pia-pf-probe.sh ca_toronto nl_amsterdam
+#   ./pia-pf-probe.sh --all               # every region advertising PF
+#   ./pia-pf-probe.sh --out results.csv
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-08-23
+
+set -euo pipefail
+
+# PIA publishes the authoritative region list here. The `port_forward` field is
+# used only to build the candidate shortlist for --all; it is never treated as
+# proof that forwarding works.
+PIA_SERVER_LIST="https://serverlist.piaservers.net/vpninfo/servers/v4"
+PIA_TOKEN_URL="https://www.privateinternetaccess.com/gtoken/generateToken"
+
+# PF API listens on the tunnel gateway once a tunnel is established.
+PF_PORT=19999
+
+# Image already present on the server; reused so the probe pulls nothing new.
+PROBE_IMAGE="docker.io/haugene/transmission-openvpn:latest"
+PROBE_CONTAINER="pia-pf-probe"
+
+# Regions worth testing first. Ordered by a mix of geographic proximity to the
+# server and PIA's historical port-forward reliability.
+DEFAULT_REGIONS=(
+  ca_toronto
+  ca_vancouver
+  nl_amsterdam
+  de_germany-so
+  ch_switzerland
+  sweden
+  romania
+)
+
+# How long to wait for the tunnel to come up before giving up on a region.
+TUNNEL_TIMEOUT=90
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+log() { printf '%s\n' "$*"; }
+log_ts() {
+  local now
+  now="$(date '+%Y-%m-%d %H:%M:%S')"
+  printf '%s %s\n' "${now}" "$*"
+}
+warn() { printf '⚠️  %s\n' "$*" >&2; }
+die() {
+  printf '❌ %s\n' "$*" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+require_deps() {
+  local missing=()
+  local dep
+  for dep in podman jq curl; do
+    command -v "${dep}" >/dev/null 2>&1 || missing+=("${dep}")
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    die "Missing required commands: ${missing[*]}"
+  fi
+}
+
+# The probe needs the same PIA credentials the live container uses. Read them
+# from the operator's env file rather than taking them on the command line, so
+# the password never lands in shell history or the process table.
+load_credentials() {
+  local env_file="${PIA_ENV_FILE:-${HOME}/containers/transmission/.env}"
+
+  [[ -r "${env_file}" ]] || die "Cannot read PIA env file: ${env_file}
+   Set PIA_ENV_FILE to override, or run as the operator account."
+
+  PIA_USERNAME="$(grep -E '^PIA_USERNAME=' "${env_file}" | cut -d= -f2-)"
+  PIA_PASSWORD="$(grep -E '^PIA_PASSWORD=' "${env_file}" | cut -d= -f2-)"
+
+  [[ -n "${PIA_USERNAME}" ]] || die "PIA_USERNAME missing from ${env_file}"
+  [[ -n "${PIA_PASSWORD}" ]] || die "PIA_PASSWORD missing from ${env_file}"
+}
+
+# ---------------------------------------------------------------------------
+# Region discovery
+# ---------------------------------------------------------------------------
+
+# Emit every region id whose advertised port_forward flag is true. This is a
+# candidate filter only — each one still has to prove itself via probe.
+list_pf_regions() {
+  curl --silent --show-error --max-time 30 "${PIA_SERVER_LIST}" \
+    | head -1 \
+    | jq -r '.regions[] | select(.port_forward == true) | .id' \
+    | sort
+}
+
+# ---------------------------------------------------------------------------
+# Probe a single region
+# ---------------------------------------------------------------------------
+
+cleanup_probe_container() {
+  podman rm -f "${PROBE_CONTAINER}" >/dev/null 2>&1 || true
+}
+
+# Bring up a throwaway tunnel for one region and report what the PF API says.
+#
+# Echoes a single CSV row:
+#   region,tunnel_up,pf_status,port,gateway,notes
+probe_region() {
+  local region="$1"
+  local tunnel_up="no"
+  local port=""
+  local gateway=""
+
+  cleanup_probe_container
+
+  # --cap-add NET_ADMIN and /dev/net/tun are what OpenVPN needs to build the
+  # tunnel. No ports are published: the probe never needs inbound access, and
+  # publishing 9091 would collide with the live container.
+  if ! podman run -d --rm \
+    --name "${PROBE_CONTAINER}" \
+    --cap-add NET_ADMIN \
+    --device /dev/net/tun \
+    -e "OPENVPN_PROVIDER=PIA" \
+    -e "OPENVPN_CONFIG=${region}" \
+    -e "OPENVPN_USERNAME=${PIA_USERNAME}" \
+    -e "OPENVPN_PASSWORD=${PIA_PASSWORD}" \
+    -e "TRANSMISSION_DOWNLOAD_DIR=/tmp" \
+    "${PROBE_IMAGE}" >/dev/null 2>&1; then
+    printf '%s,no,container_failed,,,could not start probe container\n' "${region}"
+    return 0
+  fi
+
+  # Wait for the tunnel. A region with no reachable server never gets here.
+  local waited=0
+  while [[ ${waited} -lt ${TUNNEL_TIMEOUT} ]]; do
+    gateway="$(podman exec "${PROBE_CONTAINER}" sh -c \
+      "ip route 2>/dev/null | grep tun | grep -v src | head -1 | awk '{print \$3}'" 2>/dev/null || true)"
+    if [[ -n "${gateway}" ]]; then
+      tunnel_up="yes"
+      break
+    fi
+    sleep 5
+    waited=$((waited + 5))
+  done
+
+  if [[ "${tunnel_up}" != "yes" ]]; then
+    cleanup_probe_container
+    printf '%s,no,tunnel_timeout,,,no tunnel after %ss\n' "${region}" "${TUNNEL_TIMEOUT}"
+    return 0
+  fi
+
+  # Next-generation PIA port forwarding is a two-step flow: obtain a bearer
+  # token from the account API, then present it to the PF service running on
+  # the tunnel gateway.
+  # Credentials are handed to the exec as environment variables rather than
+  # interpolated into the command string, so they never appear in the
+  # container's process table. This mirrors the --env-file protection the live
+  # container relies on.
+  local token
+  token="$(podman exec \
+    -e "PIA_USERNAME=${PIA_USERNAME}" \
+    -e "PIA_PASSWORD=${PIA_PASSWORD}" \
+    -e "PIA_TOKEN_URL=${PIA_TOKEN_URL}" \
+    "${PROBE_CONTAINER}" sh -c \
+    'curl --silent --show-error --request POST --max-time 15 \
+       --user "${PIA_USERNAME}:${PIA_PASSWORD}" "${PIA_TOKEN_URL}" | jq -r .token' 2>/dev/null || true)"
+
+  if [[ -z "${token}" || "${token}" == "null" ]]; then
+    cleanup_probe_container
+    printf '%s,yes,token_failed,,%s,could not obtain auth token\n' "${region}" "${gateway}"
+    return 0
+  fi
+
+  # The PF endpoint uses a certificate valid for a PIA hostname rather than the
+  # gateway IP we reach it by, so --insecure is required here. The token in the
+  # request is what actually authenticates this call.
+  local sig_response
+  sig_response="$(podman exec \
+    -e "PF_TOKEN=${token}" \
+    -e "PF_URL=https://${gateway}:${PF_PORT}/getSignature" \
+    "${PROBE_CONTAINER}" sh -c \
+    'curl --insecure --get --silent --show-error --max-time 15 \
+       --data-urlencode "token=${PF_TOKEN}" "${PF_URL}"' 2>/dev/null || true)"
+
+  if [[ -z "${sig_response}" ]]; then
+    cleanup_probe_container
+    printf '%s,yes,no_pf_service,,%s,nothing listening on %s\n' \
+      "${region}" "${gateway}" "${PF_PORT}"
+    return 0
+  fi
+
+  local status
+  status="$(printf '%s' "${sig_response}" | jq -r '.status // "unparseable"' 2>/dev/null || echo unparseable)"
+
+  if [[ "${status}" != "OK" ]]; then
+    cleanup_probe_container
+    printf '%s,yes,%s,,%s,getSignature did not return OK\n' "${region}" "${status}" "${gateway}"
+    return 0
+  fi
+
+  # A successful signature carries a base64 payload holding the assigned port.
+  # Decoded inside the container, which is Linux, so GNU `base64 -d` applies;
+  # running this step on macOS would need -D instead.
+  local payload
+  payload="$(jq -r '.payload' <<<"${sig_response}" 2>/dev/null || true)"
+  port="$(podman exec -e "PF_PAYLOAD=${payload}" "${PROBE_CONTAINER}" sh -c \
+    'printf %s "${PF_PAYLOAD}" | base64 -d | jq -r .port' 2>/dev/null || true)"
+
+  cleanup_probe_container
+
+  if [[ -z "${port}" || "${port}" == "null" ]]; then
+    printf '%s,yes,OK_no_port,,%s,signature OK but payload had no port\n' "${region}" "${gateway}"
+    return 0
+  fi
+
+  printf '%s,yes,OK,%s,%s,port forwarding confirmed\n' "${region}" "${port}" "${gateway}"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  local out_file="pia-pf-probe-results.csv"
+  local regions=()
+  local use_all=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --all)
+        use_all=true
+        shift
+        ;;
+      --out)
+        out_file="${2:?--out requires a path}"
+        shift 2
+        ;;
+      -h | --help)
+        sed -n '3,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+        return 0
+        ;;
+      -*)
+        die "Unknown option: $1"
+        ;;
+      *)
+        regions+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  require_deps
+  load_credentials
+
+  if [[ "${use_all}" == "true" ]]; then
+    log "Fetching regions advertising port_forward=true..."
+    local region_list
+    region_list="$(list_pf_regions)"
+    mapfile -t regions <<<"${region_list}"
+    log "${#regions[@]} candidate regions"
+  elif [[ ${#regions[@]} -eq 0 ]]; then
+    regions=("${DEFAULT_REGIONS[@]}")
+  fi
+
+  [[ ${#regions[@]} -gt 0 ]] || die "No regions to probe"
+
+  trap cleanup_probe_container EXIT
+
+  printf 'region,tunnel_up,pf_status,port,gateway,notes\n' >"${out_file}"
+
+  log_ts "Probing ${#regions[@]} region(s) — roughly $((${#regions[@]} * 90 / 60)) minutes"
+  log ""
+
+  local region row confirmed=0
+  for region in "${regions[@]}"; do
+    printf '  %-24s ' "${region}"
+    row="$(probe_region "${region}")"
+    printf '%s\n' "${row}" >>"${out_file}"
+
+    local reported_port reported_status
+    case "${row}" in
+      *,OK,*)
+        reported_port="$(cut -d, -f4 <<<"${row}")"
+        printf '✅ port %s\n' "${reported_port}"
+        confirmed=$((confirmed + 1))
+        ;;
+      *)
+        reported_status="$(cut -d, -f3 <<<"${row}")"
+        printf '❌ %s\n' "${reported_status}"
+        ;;
+    esac
+  done
+
+  log ""
+  log_ts "Done — ${confirmed}/${#regions[@]} region(s) with working port forwarding"
+  log "Results: ${out_file}"
+
+  if [[ ${confirmed} -eq 0 ]]; then
+    warn "No region returned a usable forwarded port."
+    warn "If a broad sweep (--all) also comes back empty, PIA may have curtailed"
+    warn "port forwarding for this account; running unforwarded is the fallback."
+    return 1
+  fi
+}
+
+# Entry point — skipped when sourced for tests (TEST_RUNNER=true)
+if [[ "${TEST_RUNNER:-false}" != "true" ]]; then
+  main "$@"
+fi

--- a/app-setup/templates/pia-port-guard.sh
+++ b/app-setup/templates/pia-port-guard.sh
@@ -31,8 +31,12 @@
 
 # Valid TCP/UDP port for peer traffic. Ports below 1024 are privileged and PIA
 # never assigns them, so anything in that range signals a malformed response.
-readonly PORT_MIN=1024
-readonly PORT_MAX=65535
+#
+# Deliberately not `readonly`: update-port.sh runs an infinite retry loop and
+# may source this file more than once, which would abort under `set -e` if
+# these were immutable.
+PIA_GUARD_PORT_MIN=1024
+PIA_GUARD_PORT_MAX=65535
 
 guard_log() {
   local now
@@ -52,8 +56,8 @@ is_valid_port() {
 
   # Guard against values like 00080 that are numeric but not a real port, and
   # against anything outside the unprivileged range.
-  [[ "${port}" -ge "${PORT_MIN}" ]] || return 1
-  [[ "${port}" -le "${PORT_MAX}" ]] || return 1
+  [[ "${port}" -ge "${PIA_GUARD_PORT_MIN}" ]] || return 1
+  [[ "${port}" -le "${PIA_GUARD_PORT_MAX}" ]] || return 1
 
   return 0
 }

--- a/app-setup/templates/pia-port-guard.sh
+++ b/app-setup/templates/pia-port-guard.sh
@@ -1,0 +1,118 @@
+# shellcheck shell=bash
+#
+# pia-port-guard.sh — validate a PIA forwarded port before applying it
+#
+# This is a sourced library, not an executable script; it defines functions and
+# runs nothing on its own.
+#
+# The upstream haugene/transmission-openvpn image ships an update-port.sh whose
+# error handling makes a bad situation worse. When getSignature fails it logs
+# "the has been a fatal_error" and then carries on regardless, leaving $pf_port
+# empty. The empty value flows into:
+#
+#     transmission-remote "$HOST" -p ""
+#
+# which sets Transmission's listen port to 0. With no peer port, tracker
+# announces fail and magnet links cannot retrieve metadata over DHT, so
+# downloads stop entirely rather than merely running unforwarded. The script
+# then prints "SUCCESS" with a blank "Port:" line, so the logs claim everything
+# is fine. Observed in production 2026-08-21 through 2026-08-23 (issue #159).
+#
+# This guard is the missing validation. Source it and call apply_port to make
+# the empty-port case a no-op that preserves whatever port Transmission is
+# already using.
+#
+# Usage (from a patched update-port.sh):
+#     source /etc/openvpn/pia/pia-port-guard.sh
+#     apply_port "$pf_port" "$TRANSMISSION_HOST" "${myauth_array[@]}"
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-08-23
+
+# Valid TCP/UDP port for peer traffic. Ports below 1024 are privileged and PIA
+# never assigns them, so anything in that range signals a malformed response.
+readonly PORT_MIN=1024
+readonly PORT_MAX=65535
+
+guard_log() {
+  local now
+  now="$(date '+%Y-%m-%d %H:%M:%S')"
+  printf '%s %s\n' "${now}" "$*"
+}
+
+# Return 0 only for a value that is safe to hand to transmission-remote -p.
+#
+# Rejects: empty strings, whitespace, non-numeric values, the literal "null"
+# that jq emits for a missing field, and out-of-range numbers.
+is_valid_port() {
+  local port="${1:-}"
+
+  [[ -n "${port}" ]] || return 1
+  [[ "${port}" =~ ^[0-9]+$ ]] || return 1
+
+  # Guard against values like 00080 that are numeric but not a real port, and
+  # against anything outside the unprivileged range.
+  [[ "${port}" -ge "${PORT_MIN}" ]] || return 1
+  [[ "${port}" -le "${PORT_MAX}" ]] || return 1
+
+  return 0
+}
+
+# Read the port Transmission is currently listening on, or empty if it cannot
+# be determined. Used to decide whether an update is actually needed.
+# Auth is passed as zero or more separate arguments ("--auth" "user:pass")
+# rather than one pre-joined string, so no word splitting is required.
+current_peer_port() {
+  local host="$1"
+  shift
+  local auth=("$@")
+
+  local session_info
+  session_info="$(transmission-remote "${host}" "${auth[@]}" -si 2>/dev/null || true)"
+
+  local listen_line
+  listen_line="$(grep -iE 'Listen ?port' <<<"${session_info}" || true)"
+
+  local digits
+  digits="$(grep -oE '[0-9]+' <<<"${listen_line}" || true)"
+
+  head -1 <<<"${digits}"
+}
+
+# Apply a forwarded port to Transmission, refusing to apply an invalid one.
+#
+# Returns 0 when the port was applied or was already correct, 1 when the port
+# was rejected. A rejection deliberately leaves Transmission untouched: running
+# unforwarded on a stale-but-valid port is far better than running with port 0.
+apply_port() {
+  local new_port="${1:-}"
+  local host="$2"
+  shift 2
+  local auth=("$@")
+
+  if ! is_valid_port "${new_port}"; then
+    local existing
+    existing="$(current_peer_port "${host}" "${auth[@]}")"
+
+    guard_log "REFUSING to apply invalid port forwarding result: '${new_port}'"
+    guard_log "  Port forwarding is unavailable; Transmission left unchanged."
+    if [[ -n "${existing}" && "${existing}" != "0" ]]; then
+      guard_log "  Keeping existing peer port ${existing} (unforwarded)."
+    else
+      guard_log "  WARNING: Transmission has no valid peer port (currently ${existing:-unknown})."
+      guard_log "  Magnet links will not resolve until a peer port is set."
+    fi
+    return 1
+  fi
+
+  local existing
+  existing="$(current_peer_port "${host}" "${auth[@]}")"
+
+  if [[ "${existing}" == "${new_port}" ]]; then
+    guard_log "Peer port already ${new_port}; no change needed."
+    return 0
+  fi
+
+  guard_log "Setting Transmission peer port to ${new_port}"
+  transmission-remote "${host}" "${auth[@]}" -p "${new_port}"
+}

--- a/docs/apps/pia-vpn-README.md
+++ b/docs/apps/pia-vpn-README.md
@@ -1,0 +1,253 @@
+# PIA VPN — credentials, port forwarding, and region selection
+
+Covers the PIA VPN layer beneath containerized Transmission: where the account
+credentials live, how to rotate them, how port forwarding is supposed to work,
+and how to diagnose it when it stops.
+
+For the media-processing pipeline that runs after a download completes, see
+[transmission-filebot-README.md](transmission-filebot-README.md).
+
+## Architecture
+
+Transmission runs inside the `transmission-vpn` container
+(`haugene/transmission-openvpn`) on the `transmission-vm` Podman machine, owned
+by the `operator` account. All of its traffic egresses through an OpenVPN
+tunnel to PIA. If the tunnel drops, the container's killswitch stops traffic
+rather than leaking it.
+
+Two separate things are often confused when debugging:
+
+- **The tunnel** — carries all outbound traffic. When this breaks, nothing
+  reaches the internet at all.
+- **Port forwarding** — asks PIA to open an inbound port so remote peers can
+  connect *to* us. When only this breaks, downloads still work but run
+  outbound-only.
+
+## Credential chain
+
+The PIA account password flows through four places. Each one has to be updated
+during a rotation, in order.
+
+```
+1Password  ──prep-airdrop.sh──▶  macOS keychain  ──setup script──▶  .env  ──podman run──▶  container
+```
+
+| Stage | Location | Notes |
+| --- | --- | --- |
+| Source of truth | 1Password item (`ONEPASSWORD_PIA_ITEM`) | Read only during prep, on the dev Mac |
+| Server storage | Keychain `pia-account-<hostname>` | Stored as `username:password`, colon-delimited |
+| Container input | `~operator/containers/transmission/.env` | Mode `0600`, owned `operator:staff` |
+| Runtime | Container environment | Unavoidably plaintext; OpenVPN needs it |
+
+`.env` is passed with `--env-file`, never as inline `-e` flags, so the password
+does not appear in `ps` output on the host.
+
+## Rotating the PIA password
+
+Do these in order. Skipping step 2 is the usual mistake — the container reads
+the keychain-derived `.env`, not 1Password, so a rotation that stops at
+1Password leaves the server authenticating with the old password until the next
+full re-provision.
+
+### 1. Change the password at PIA and in 1Password
+
+Rotate it in the PIA account portal, then update the 1Password item so future
+provisioning runs pick up the new value.
+
+### 2. Update the keychain on the server
+
+On TILSIT, as the account that owns the entry:
+
+```bash
+security add-generic-password -U \
+  -s "pia-account-tilsit" \
+  -a "tilsit" \
+  -w
+```
+
+Omitting a value after `-w` makes `security` prompt for it interactively, which
+keeps the password out of shell history and the process table. At the prompt,
+enter the full colon-delimited pair:
+
+```
+p3462742:NEW_PASSWORD_HERE
+```
+
+`-U` updates the existing entry instead of failing on a duplicate.
+
+Verify the entry is present (this prints metadata, not the secret):
+
+```bash
+security find-generic-password -s "pia-account-tilsit" -a "tilsit"
+```
+
+### 3. Regenerate `.env` and recreate the container
+
+```bash
+sudo ./app-setup/podman-transmission-setup.sh
+```
+
+This re-reads the keychain, rewrites `.env` at mode 600, and recreates the
+container.
+
+**The container must be recreated, not restarted.** `--env-file` is read at
+creation time only, so `podman restart` keeps the old credential in the
+existing container's environment.
+
+### 4. Verify
+
+```bash
+# Tunnel established and egressing through PIA
+sudo -u operator podman exec transmission-vpn curl -s https://ipinfo.io/ip
+
+# No auth failures in the log
+sudo -u operator podman logs --tail 50 transmission-vpn | grep -i "auth"
+```
+
+A wrong password shows up as `AUTH_FAILED` in the container log, with the
+tunnel repeatedly reconnecting.
+
+## Port forwarding
+
+PIA's next-generation port forwarding is a two-step flow, implemented in the
+image's `/etc/openvpn/pia/update-port.sh`:
+
+1. `POST https://www.privateinternetaccess.com/gtoken/generateToken` with the
+   account credentials, returning a bearer token.
+2. `GET https://<tunnel-gateway>:19999/getSignature` with that token, returning
+   a signed payload containing the assigned port, then `bindPort` to reserve
+   it.
+
+The assigned port is then pushed into Transmission with
+`transmission-remote -p <port>`.
+
+### `port_forward=true` cannot be trusted
+
+PIA publishes a region list at
+`https://serverlist.piaservers.net/vpninfo/servers/v4` with a per-region
+`port_forward` boolean. **That flag is advisory and is known to be wrong.**
+
+Verified 2026-08-23: the Panama region advertises `port_forward: true` while
+serving nothing on port 19999 — every host in the region refuses the
+connection, including the `meta` and `ovpnudp` servers PIA itself advertises
+for that region. 103 of 158 regions carry the flag, so it is useful as a
+first-pass filter and nothing more.
+
+The only reliable test is to establish a tunnel and ask. That is what
+[`app-setup/templates/pia-pf-probe.sh`](../../app-setup/templates/pia-pf-probe.sh)
+does:
+
+```bash
+# Probe the default shortlist
+sudo -u operator ./app-setup/templates/pia-pf-probe.sh
+
+# Probe specific regions
+sudo -u operator ./app-setup/templates/pia-pf-probe.sh ca_toronto nl_amsterdam
+
+# Sweep everything advertising PF (slow — roughly 90s per region)
+sudo -u operator ./app-setup/templates/pia-pf-probe.sh --all --out results.csv
+```
+
+The probe runs in its own throwaway container and does not disturb the live
+`transmission-vpn` container or any download in progress.
+
+It reads credentials from the same `.env` the live container uses, and passes
+them into the probe container as environment variables on the `podman exec`
+rather than interpolating them into command strings — so they stay out of the
+process table, matching the `--env-file` protection described above.
+
+Changing regions means setting `PIA_VPN_REGION` (default `panama`) and
+recreating the container.
+
+## Diagnosing "torrents won't start"
+
+Symptoms and what they mean, in the order worth checking.
+
+### Is it the tunnel or just port forwarding?
+
+```bash
+sudo -u operator podman exec transmission-vpn curl -s https://ipinfo.io/ip
+```
+
+A PIA exit IP means the tunnel is fine and the problem is narrower.
+
+### Check the listen port
+
+```bash
+transmission-remote localhost:9091 -si | grep -i "listen port"
+```
+
+`Listen port: 0` means port forwarding failed **and** took the peer port with
+it. This is the failure mode that stops downloads entirely rather than merely
+slowing them — see below.
+
+### Check whether PF is reachable at all
+
+```bash
+GW=$(sudo -u operator podman exec transmission-vpn sh -c \
+  "ip route | grep tun | grep -v src | head -1 | awk '{print \$3}'")
+sudo -u operator podman exec transmission-vpn \
+  curl --insecure -s -o /dev/null -w '%{http_code}\n' --max-time 6 \
+  "https://${GW}:19999/getSignature"
+```
+
+An immediate connection refused (sub-100ms) means the region serves no PF at
+all. Run the probe script to find one that does.
+
+## Known failure mode: empty port zeroes Transmission
+
+The upstream image's `update-port.sh` has an error-handling bug. When
+`getSignature` fails it logs `the has been a fatal_error` and then **continues
+anyway**, leaving `$pf_port` empty. That empty value reaches:
+
+```bash
+transmission-remote "$HOST" -p ""
+```
+
+which sets Transmission's listen port to 0. It then prints a success banner
+with a blank port:
+
+```
+#######################
+        SUCCESS
+#######################
+Port:
+```
+
+With no peer port, tracker announces fail and magnet links cannot retrieve
+metadata over DHT, so downloads never start. The retry loop repeats this every
+15 minutes, re-zeroing the port after any manual fix.
+
+This is strictly worse than doing nothing: an unforwarded Transmission on a
+valid port still downloads from seeders, just more slowly.
+
+[`app-setup/templates/pia-port-guard.sh`](../../app-setup/templates/pia-port-guard.sh)
+is the validation the upstream script lacks. Source it from a patched
+`update-port.sh` and call `apply_port`, which refuses empty, non-numeric,
+`null`, zero, privileged, and out-of-range values, leaving the existing port
+intact instead.
+
+Covered by `tests/pia-port-guard.bats`.
+
+## Monitoring note
+
+Port-forwarding loss is not always visible from download activity. Well-seeded
+torrents continue to work unforwarded via outbound connections, so a monitor
+that only asks "are downloads moving?" will miss it. Assert on the listen port
+directly:
+
+```bash
+transmission-remote localhost:9091 -si | grep -i "listen port"
+# Alert when this reports 0
+```
+
+Observed 2026-08-21 → 2026-08-23: port forwarding was broken for roughly 47
+hours before it was noticed, and only became visible when a newly added magnet
+link failed to resolve.
+
+## Related
+
+- Issue #159 — dynamic VPN endpoint selection, including PF verification as a
+  gating criterion
+- [transmission-filebot-README.md](transmission-filebot-README.md) — the
+  post-download processing pipeline

--- a/tests/pia-port-guard.bats
+++ b/tests/pia-port-guard.bats
@@ -166,3 +166,15 @@ teardown() {
   [ "$status" -eq 0 ]
   ! grep -q -- "--auth" "${CALL_LOG}"
 }
+
+# --- idempotency ------------------------------------------------------------
+
+@test "guard can be sourced twice without error" {
+  # update-port.sh retries in an infinite loop and may re-source the guard.
+  # readonly constants here would abort the caller under `set -e`.
+  run bash -c "set -euo pipefail
+    source '${GUARD}'
+    source '${GUARD}'
+    is_valid_port 54321"
+  [ "$status" -eq 0 ]
+}

--- a/tests/pia-port-guard.bats
+++ b/tests/pia-port-guard.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+#
+# Tests for pia-port-guard template — validates that invalid port-forwarding
+# results are refused rather than applied to Transmission.
+#
+# The production incident these guard against (issue #159): upstream
+# update-port.sh let an empty $pf_port reach `transmission-remote -p ""`,
+# setting the listen port to 0 and stopping all magnet downloads. Every
+# rejection case below represents a value that must never reach Transmission.
+#
+# Run with: bats tests/pia-port-guard.bats
+
+BATS_TEST_FILENAME="${BATS_TEST_FILENAME:-}"
+REPO_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+GUARD="${REPO_DIR}/app-setup/templates/pia-port-guard.sh"
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  export TEST_TMPDIR
+
+  # Records every transmission-remote invocation so tests can assert on
+  # whether a port change was actually attempted.
+  export CALL_LOG="${TEST_TMPDIR}/calls.log"
+  touch "${CALL_LOG}"
+
+  # Port reported by the stub's -si output; tests override to simulate the
+  # daemon's current state.
+  export STUB_CURRENT_PORT="33361"
+
+  cat >"${TEST_TMPDIR}/transmission-remote" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CALL_LOG}"
+for arg in "$@"; do
+  if [[ "${arg}" == "-si" ]]; then
+    printf '  Listen port: %s\n' "${STUB_CURRENT_PORT}"
+    exit 0
+  fi
+done
+exit 0
+STUB
+  chmod +x "${TEST_TMPDIR}/transmission-remote"
+  export PATH="${TEST_TMPDIR}:${PATH}"
+
+  # shellcheck source=/dev/null
+  source "${GUARD}"
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+}
+
+# --- is_valid_port ---------------------------------------------------------
+
+@test "is_valid_port accepts a typical PIA-assigned port" {
+  run is_valid_port 54321
+  [ "$status" -eq 0 ]
+}
+
+@test "is_valid_port accepts the range boundaries" {
+  run is_valid_port 1024
+  [ "$status" -eq 0 ]
+  run is_valid_port 65535
+  [ "$status" -eq 0 ]
+}
+
+@test "is_valid_port rejects an empty string (the production failure)" {
+  run is_valid_port ""
+  [ "$status" -ne 0 ]
+}
+
+@test "is_valid_port rejects a missing argument" {
+  run is_valid_port
+  [ "$status" -ne 0 ]
+}
+
+@test "is_valid_port rejects jq's null for a missing payload field" {
+  run is_valid_port "null"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_valid_port rejects whitespace" {
+  run is_valid_port "   "
+  [ "$status" -ne 0 ]
+}
+
+@test "is_valid_port rejects non-numeric junk" {
+  run is_valid_port "abc"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_valid_port rejects zero" {
+  run is_valid_port 0
+  [ "$status" -ne 0 ]
+}
+
+@test "is_valid_port rejects privileged ports" {
+  run is_valid_port 80
+  [ "$status" -ne 0 ]
+}
+
+@test "is_valid_port rejects ports above the 16-bit maximum" {
+  run is_valid_port 65536
+  [ "$status" -ne 0 ]
+}
+
+@test "is_valid_port rejects negative numbers" {
+  run is_valid_port -- "-1"
+  [ "$status" -ne 0 ]
+}
+
+# --- apply_port ------------------------------------------------------------
+
+@test "apply_port sets a valid port that differs from the current one" {
+  export STUB_CURRENT_PORT="33361"
+  run apply_port 54321 "http://localhost:9091/transmission/rpc"
+  [ "$status" -eq 0 ]
+  grep -q -- "-p 54321" "${CALL_LOG}"
+}
+
+@test "apply_port skips the update when the port is unchanged" {
+  export STUB_CURRENT_PORT="54321"
+  run apply_port 54321 "http://localhost:9091/transmission/rpc"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no change needed"* ]]
+  ! grep -q -- "-p 54321" "${CALL_LOG}"
+}
+
+@test "apply_port refuses an empty port and never calls -p" {
+  export STUB_CURRENT_PORT="33361"
+  run apply_port "" "http://localhost:9091/transmission/rpc"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"REFUSING"* ]]
+  ! grep -q -- " -p " "${CALL_LOG}"
+}
+
+@test "apply_port reports the preserved port when refusing" {
+  export STUB_CURRENT_PORT="33361"
+  run apply_port "" "http://localhost:9091/transmission/rpc"
+  [[ "$output" == *"Keeping existing peer port 33361"* ]]
+}
+
+@test "apply_port warns when Transmission is already at port 0" {
+  export STUB_CURRENT_PORT="0"
+  run apply_port "" "http://localhost:9091/transmission/rpc"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no valid peer port"* ]]
+}
+
+@test "apply_port refuses jq null without calling -p" {
+  export STUB_CURRENT_PORT="33361"
+  run apply_port "null" "http://localhost:9091/transmission/rpc"
+  [ "$status" -ne 0 ]
+  ! grep -q -- " -p " "${CALL_LOG}"
+}
+
+@test "apply_port passes auth arguments through without word splitting" {
+  export STUB_CURRENT_PORT="33361"
+  run apply_port 54321 "http://localhost:9091/transmission/rpc" --auth "user:pass with spaces"
+  [ "$status" -eq 0 ]
+  grep -q -- "--auth user:pass with spaces" "${CALL_LOG}"
+}
+
+@test "apply_port works with no auth arguments supplied" {
+  export STUB_CURRENT_PORT="33361"
+  run apply_port 54321 "http://localhost:9091/transmission/rpc"
+  [ "$status" -eq 0 ]
+  ! grep -q -- "--auth" "${CALL_LOG}"
+}


### PR DESCRIPTION
## Why

Magnet links stopped resolving entirely — including well-seeded public torrents
used as a control. Transmission itself was healthy the whole time: daemon
responding on RPC, container up and healthy, tunnel established, general
internet working through it.

Two things were wrong.

**PIA's Panama region serves no port forwarding**, despite advertising
`port_forward: true` in PIA's own server list. Probed port 19999 on the
advertised `ovpnudp` server, the `meta` server, and the connected gateway —
all refused, sub-100ms. 103 of 158 regions carry that flag, so it is a
candidate filter and nothing more.

**The upstream `update-port.sh` turns that into a total outage.** When
`getSignature` fails it logs `the has been a fatal_error` and then continues
anyway, leaving `$pf_port` empty and pushing it into Transmission:

```
setting transmission port to        <-- empty
```

Listen port goes to 0. With no peer port, tracker announces fail and magnets
cannot retrieve metadata over DHT, so nothing starts at all. It then prints a
`SUCCESS` banner with a blank `Port:` line, and the retry loop re-zeroes the
port every 15 minutes. This had never worked on that connection — first
failure was 12 seconds after container start, and the log contains zero
successful port assignments.

An unforwarded Transmission on a valid port still downloads, just more slowly.
Port 0 downloads nothing.

## What this adds

**`pia-pf-probe.sh`** — establishes a tunnel per candidate region and asks the
PF API for a real port, since the advertised flag can't be trusted. Runs in its
own throwaway container, so it doesn't disturb the live one or any download in
progress. Emits CSV for the region-ranking work in #159.

**`pia-port-guard.sh`** — the validation upstream lacks. Refuses empty,
non-numeric, `null`, zero, privileged, and out-of-range ports, leaving the
existing peer port intact instead of zeroing it.

**`docs/apps/pia-vpn-README.md`** — credential chain and password rotation
(the keychain step is easy to miss; skipping it leaves the server on the old
password until the next re-provision), PF diagnosis, and a note that PF loss is
invisible to download-activity monitoring — well-seeded torrents keep working
unforwarded, which is why this went unnoticed for ~47 hours.

## Testing

20 BATS tests, full suite 246 passing / 0 failing. shellcheck `-S info` and
shfmt clean, no `disable` directives.

The rejection tests were validated against a deliberately broken guard that
applies whatever it's given: it fails exactly the four rejection cases,
including the empty-port production bug. They catch the real thing rather than
passing vacuously.

## Not included

The patch to `update-port.sh` that actually calls `apply_port`. The guard ships
as a library first so it can be reviewed on its own; wiring it in touches the
running container and belongs in a separate change.

## Notes

- Does not fix the outage on its own — a region that actually serves PF still
  has to be selected. The probe is what finds one.
- Findings and a correction to an earlier wrong diagnosis are recorded on #159.
- Pre-push review filed four non-blocking observations as #171.

Refs #159
