### PR TITLE
fix(pia): make PF probe actually establish a tunnel

### DIFF
--- a/app-setup/templates/pia-pf-probe.sh
+++ b/app-setup/templates/pia-pf-probe.sh
@@ -20,6 +20,10 @@
 #   ./pia-pf-probe.sh                     # probe the default shortlist
 #   ./pia-pf-probe.sh ca_toronto nl_amsterdam
 #   ./pia-pf-probe.sh --all               # every region advertising PF
+#
+# Region arguments are the image's OpenVPN config names, not PIA's API region
+# ids; the two do not always agree. --all enumerates API ids and will report
+# tunnel_timeout for any region whose config name differs (issue #159).
 #   ./pia-pf-probe.sh --out results.csv
 #
 # Author: Andrew Rich <andrew.rich@gmail.com>
@@ -40,15 +44,22 @@ PF_PORT=19999
 PROBE_IMAGE="docker.io/haugene/transmission-openvpn:latest"
 PROBE_CONTAINER="pia-pf-probe"
 
-# Regions worth testing first. Ordered by a mix of geographic proximity to the
-# server and PIA's historical port-forward reliability.
+# Regions worth testing first, all verified working 2026-08-23.
+#
+# These are the IMAGE's OpenVPN config names, which are not always PIA's API
+# region ids: the API calls them nl_amsterdam / ch_switzerland / sweden, while
+# the image ships netherlands / switzerland / se_stockholm. An unknown name
+# does not fail loudly — the container prints its config list and exits, which
+# this script can only observe as a tunnel timeout. See issue #159.
+#
+# `podman run --rm <image> ls /etc/openvpn/pia/` lists the valid names.
 DEFAULT_REGIONS=(
   ca_toronto
   ca_vancouver
-  nl_amsterdam
-  de_germany-so
-  ch_switzerland
-  sweden
+  netherlands
+  de_frankfurt
+  switzerland
+  se_stockholm
   romania
 )
 
@@ -135,20 +146,30 @@ probe_region() {
 
   cleanup_probe_container
 
-  # --cap-add NET_ADMIN and /dev/net/tun are what OpenVPN needs to build the
-  # tunnel. No ports are published: the probe never needs inbound access, and
-  # publishing 9091 would collide with the live container.
+  # Flags mirror the live transmission-vpn container, which is the known-working
+  # configuration on this host.
+  #
+  # CREATE_TUN_DEVICE=false is load-bearing: Podman already supplies
+  # /dev/net/tun via --device, and without this the image tries to create it
+  # itself, fails with "cannot remove '/dev/net/tun': Device or resource busy",
+  # and the container exits before a tunnel is ever attempted.
+  #
+  # No ports are published: the probe needs no inbound access, and publishing
+  # 9091 would collide with the live container.
+  #
   # No --rm: it races with the explicit cleanup below, and a SIGKILLed script
   # would leave the container behind either way. cleanup_probe_container plus
   # the EXIT trap is the single cleanup path.
   if ! podman run -d \
     --name "${PROBE_CONTAINER}" \
-    --cap-add NET_ADMIN \
-    --device /dev/net/tun \
+    --privileged \
+    --device /dev/net/tun:/dev/net/tun \
     -e "OPENVPN_PROVIDER=PIA" \
     -e "OPENVPN_CONFIG=${region}" \
     -e "OPENVPN_USERNAME=${PIA_USERNAME}" \
     -e "OPENVPN_PASSWORD=${PIA_PASSWORD}" \
+    -e "CREATE_TUN_DEVICE=false" \
+    -e "LOG_TO_STDOUT=true" \
     -e "TRANSMISSION_DOWNLOAD_DIR=/tmp" \
     "${PROBE_IMAGE}" >/dev/null 2>&1; then
     printf '%s,no,container_failed,,,could not start probe container\n' "${region}"

--- a/app-setup/templates/pia-pf-probe.sh
+++ b/app-setup/templates/pia-pf-probe.sh
@@ -18,7 +18,7 @@
 #
 # Usage:
 #   ./pia-pf-probe.sh                     # probe the default shortlist
-#   ./pia-pf-probe.sh ca_toronto nl_amsterdam
+#   ./pia-pf-probe.sh ca_toronto netherlands
 #   ./pia-pf-probe.sh --all               # every region advertising PF
 #
 # Region arguments are the image's OpenVPN config names, not PIA's API region

--- a/docs/apps/pia-vpn-README.md
+++ b/docs/apps/pia-vpn-README.md
@@ -142,7 +142,7 @@ does:
 sudo -u operator ./app-setup/templates/pia-pf-probe.sh
 
 # Probe specific regions
-sudo -u operator ./app-setup/templates/pia-pf-probe.sh ca_toronto nl_amsterdam
+sudo -u operator ./app-setup/templates/pia-pf-probe.sh ca_toronto netherlands
 
 # Sweep everything advertising PF (slow — roughly 90s per region)
 sudo -u operator ./app-setup/templates/pia-pf-probe.sh --all --out results.csv

--- a/docs/apps/pia-vpn-README.md
+++ b/docs/apps/pia-vpn-README.md
@@ -156,8 +156,55 @@ them into the probe container as environment variables on the `podman exec`
 rather than interpolating them into command strings — so they stay out of the
 process table, matching the `--env-file` protection described above.
 
+The probe container runs with `--privileged`, `--device /dev/net/tun`, and
+`CREATE_TUN_DEVICE=false`, mirroring the live container. That last one is
+load-bearing: Podman already provides the TUN device, and without it the image
+tries to create its own, fails with `cannot remove '/dev/net/tun': Device or
+resource busy`, and exits before attempting a tunnel.
+
 Changing regions means setting `PIA_VPN_REGION` (default `panama`) and
 recreating the container.
+
+### Region names: image config vs PIA API
+
+`OPENVPN_CONFIG` takes the name of a bundled `.ovpn` file in the image, which
+is **not always PIA's API region id**. The API calls them `nl_amsterdam`,
+`ch_switzerland`, and `sweden`; the image ships `netherlands`, `switzerland`,
+and `se_stockholm`.
+
+An unknown name fails quietly from the outside — the container prints its
+167-line config list and exits, so anything watching only tunnel state sees a
+timeout indistinguishable from a dead endpoint. This cost a full survey run on
+2026-08-23; five regions reported as failures were fine under their real names.
+
+List the valid names with:
+
+```bash
+sudo -u operator podman run --rm \
+  docker.io/haugene/transmission-openvpn:latest ls /etc/openvpn/pia/
+```
+
+Reconciling the two namespaces, and detecting drift as PIA adds or removes
+endpoints, is tracked in issue #159.
+
+### Verified working regions
+
+Probed 2026-08-23. Ports are per-session and will differ on reconnect; the
+point is that each region returned one.
+
+| Region (image config name) | Port | Gateway |
+| --- | --- | --- |
+| `ca_toronto` | 27251 | 10.17.112.1 |
+| `ca_vancouver` | 28284 | 10.7.112.1 |
+| `netherlands` | 34475 | 10.13.112.1 |
+| `de_frankfurt` | 46014 | 10.135.192.1 |
+| `de_berlin` | 32697 | 10.34.192.1 |
+| `switzerland` | 47931 | 10.116.192.1 |
+| `romania` | 47898 | 10.107.192.1 |
+| `se_stockholm` | 43172 | 10.80.192.1 |
+
+`panama` — the region this server has been pinned to — remains the only one
+observed serving no port forwarding at all.
 
 ## Diagnosing "torrents won't start"
 


### PR DESCRIPTION
## Why

The probe merged in #172 never actually established a tunnel. First run
reported `tunnel_timeout` on every region.

Two separate causes, both fixed here.

**Missing `CREATE_TUN_DEVICE=false`.** The probe passed `--cap-add NET_ADMIN`
and `--device /dev/net/tun`, but the image also creates its own TUN device
unless told not to. Podman already supplies it, so the image's attempt fails:

```
Creating TUN device /dev/net/tun
rm: cannot remove '/dev/net/tun': Device or resource busy
```

and the container exits before OpenVPN starts. The live `transmission-vpn`
container has always set this; the probe didn't. Flags now mirror the live
container's `CreateCommand`, which is the known-working configuration on this
host.

**Region names were PIA API ids, not image config names.** These namespaces
don't always agree: the API says `nl_amsterdam`, `ch_switzerland`, `sweden`;
the image ships `netherlands`, `switzerland`, `se_stockholm`. An unknown name
fails invisibly — the container prints its 167-line config list and exits,
which the probe can only observe as a tunnel timeout, indistinguishable from a
dead endpoint.

Five regions were reported as failures on the first survey for this reason
alone. All five work under their real names.

## Survey results

8 of 8 regions probed have working port forwarding:

| Region | Port | Gateway |
| --- | --- | --- |
| `ca_toronto` | 27251 | 10.17.112.1 |
| `ca_vancouver` | 28284 | 10.7.112.1 |
| `netherlands` | 34475 | 10.13.112.1 |
| `de_frankfurt` | 46014 | 10.135.192.1 |
| `de_berlin` | 32697 | 10.34.192.1 |
| `switzerland` | 47931 | 10.116.192.1 |
| `romania` | 47898 | 10.107.192.1 |
| `se_stockholm` | 43172 | 10.80.192.1 |

Panama — the region this server is pinned to — remains the only one observed
serving no port forwarding at all. That confirms the original diagnosis and
means the outage is fixable by moving regions.

Recorded in the README, dated, with a note that the ports are per-session and
the only durable claim is that each region returned one.

## Also here

- Default shortlist switched to verified image config names.
- Usage examples no longer show `nl_amsterdam`, which the same diff documents
  as invalid — copy-pasting it reproduced the exact failure the text warns
  about. Closes #173.
- README gains a section on the two namespaces and how to list valid names.

## Not here

Repointing the live container at a working region. That's a production change
and belongs in its own step, once you've picked one.

Namespace reconciliation and upstream drift detection (regions added/removed by
PIA, config names changing under an image update) are scoped on #159 — the
probe's `--all` mode still enumerates API ids and would mis-report any region
whose config name differs.

Refs #159
