### PR TITLE
fix(pia): move to ca_toronto, restoring port forwarding

### DIFF
--- a/config/config.conf.template
+++ b/config/config.conf.template
@@ -59,7 +59,8 @@ USE_ITERM2="false"        # Set to "true" to copy complete iTerm2 preferences fr
 # VPN and Transmission configuration (optional)
 # Used by podman-transmission-setup.sh to configure the containerized Transmission stack
 ONEPASSWORD_PIA_ITEM=""          # 1Password item name holding PIA account credentials
-PIA_VPN_REGION="panama"          # PIA server region for haugene (must match /etc/openvpn/pia/ stem)
+PIA_VPN_REGION="ca_toronto"      # PIA region for haugene (must match /etc/openvpn/pia/ stem, NOT the API region id)
+                                 # Must support port forwarding — panama advertises it but serves none (issue #159)
 LAN_SUBNET="192.168.1.0/24"      # Local network CIDR for Transmission web UI access
 TRANSMISSION_HOST_PORT="9091"    # Host port for Transmission web UI
 

--- a/docs/apps/pia-vpn-README.md
+++ b/docs/apps/pia-vpn-README.md
@@ -203,8 +203,22 @@ point is that each region returned one.
 | `romania` | 47898 | 10.107.192.1 |
 | `se_stockholm` | 43172 | 10.80.192.1 |
 
-`panama` — the region this server has been pinned to — remains the only one
-observed serving no port forwarding at all.
+`panama` — the region this server was pinned to until 2026-08-23 — remains the
+only one observed serving no port forwarding at all. **TILSIT now runs
+`ca_toronto`**, which reserved port 50454 on first connect and verified open.
+
+### On the hardcoded PF port
+
+`update-port.sh` targets port 19999 on the tunnel gateway. That number is a
+convention from PIA's reference implementation, not something PIA advertises:
+their server list publishes ports for every other service (`wg` 1337, `meta`
+443/8080, `ovpnudp` 8080/853/123/53) but nothing for port forwarding.
+
+So a refused connection on 19999 proves only that nothing is listening *there*.
+Panama failing while eight other regions succeeded makes "Panama serves no PF"
+the overwhelmingly likely reading — but if PIA ever moves the service, every
+region would look dead to this script and the probe would report a false
+negative across the board. Tracked on issue #159.
 
 ## Diagnosing "torrents won't start"
 


### PR DESCRIPTION
## The outage is fixed

TILSIT is on `ca_toronto` and port forwarding works.

```
Reserved Port: 50454
setting transmission port to 50454
```

Verified rather than assumed:

- `transmission-remote -pt` → **`Port is open: Yes`**
- Listen port **50454** (was 0)
- Exit IP 191.96.36.38, Toronto CA
- Test magnet: metadata resolved in seconds, **22 peers connected / 17
  downloading**, 278 kB/s — against 0 peers and no metadata before
- Container healthy, test torrent removed, nothing else in flight

## What changed

`PIA_VPN_REGION` moves from `panama` to `ca_toronto` in the template, so a
fresh provision doesn't land on the broken region. The live change was applied
by re-running `podman-transmission-setup.sh`, which is the supported path —
the Podman install and machine-init steps are guarded and correctly skipped on
an already-provisioned host.

`config/config.conf` is gitignored, so only the template is in the diff. The
running server's config was updated in place.

## On port 19999

Answering a question raised in review of #159: **19999 is a hardcoded
constant, not something PIA advertises.** It appears twice in the image's
`update-port.sh` and nowhere else. PIA's server list publishes ports for every
other service — `wg` 1337, `meta` 443/8080, `ovpnudp` 8080/853/123/53,
`ikev2` 500/4500 — and has no port-forwarding entry at all. The number comes
from PIA's own reference implementation (`pia-foss/manual-connections`), which
the community scripts copied.

It's correct in practice, but it means a refused connection on 19999 proves
only that nothing is listening *there*. Panama failing while eight other
regions succeeded makes "Panama serves no PF" the overwhelmingly likely
reading — but if PIA ever moved the service, every region would look dead and
the probe would report false negatives across the board. Now documented in the
README and flagged on #159, since it's an assumption the probe can't verify.

## Follow-ups, not here

- The port guard still isn't wired into `update-port.sh` — it ships as a
  library. With PF working the destructive path is dormant, but it's still
  live code that would zero the peer port on the next PF failure.
- Namespace reconciliation and upstream drift detection remain on #159.

Refs #159
