### PR TITLE
feat(pia): guarded port updater + move to ca_vancouver

### DIFF
--- a/app-setup/podman-transmission-setup.sh
+++ b/app-setup/podman-transmission-setup.sh
@@ -422,6 +422,40 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Section 6b: Deploy PIA port forwarding manager (container-side)
+# ---------------------------------------------------------------------------
+
+set_section "Deploy PIA Port Forwarding Manager"
+
+# Replaces the image's bundled update-port.sh, which zeroes Transmission's
+# listen port when PIA's port-forwarding API is unavailable (issue #159). The
+# bundled script cannot be patched in place: it sits in /etc/openvpn/pia/
+# alongside the 167 .ovpn region configs, so mounting over that directory to
+# swap one file would hide the configs. DISABLE_PORT_UPDATER=true keeps it
+# dormant while our version runs from the already-mounted /scripts volume.
+PORT_GUARD_TEMPLATE="${SCRIPT_DIR}/templates/pia-port-guard.sh"
+PORT_GUARD_DEST="${CONTAINER_DIR}/scripts/pia-port-guard.sh"
+POST_START_TEMPLATE="${SCRIPT_DIR}/templates/transmission-post-start.sh"
+POST_START_DEST="${CONTAINER_DIR}/scripts/transmission-post-start.sh"
+
+if [[ ! -f "${PORT_GUARD_TEMPLATE}" ]]; then
+  collect_error "Template not found: ${PORT_GUARD_TEMPLATE}"
+elif [[ ! -f "${POST_START_TEMPLATE}" ]]; then
+  collect_error "Template not found: ${POST_START_TEMPLATE}"
+else
+  # The guard is sourced, not executed, so it does not need the execute bit.
+  sudo cp "${PORT_GUARD_TEMPLATE}" "${PORT_GUARD_DEST}"
+  sudo chmod 644 "${PORT_GUARD_DEST}"
+  sudo chown "${OPERATOR_USERNAME}:staff" "${PORT_GUARD_DEST}"
+
+  sudo cp "${POST_START_TEMPLATE}" "${POST_START_DEST}"
+  sudo chmod 755 "${POST_START_DEST}"
+  sudo chown "${OPERATOR_USERNAME}:staff" "${POST_START_DEST}"
+
+  log "✅ PIA port forwarding manager deployed (guard + post-start hook)"
+fi
+
+# ---------------------------------------------------------------------------
 # Section 7: Deploy transmission-trigger-watcher.sh (macOS LaunchAgent daemon)
 # ---------------------------------------------------------------------------
 
@@ -574,6 +608,8 @@ ensure_container() {
         --env-file "${OPERATOR_HOME}/containers/transmission/.env" \\
         -e OPENVPN_PROVIDER=PIA \\
         -e "OPENVPN_CONFIG=${PIA_REGION}" \\
+        -e "DISABLE_PORT_UPDATER=true" \\
+        -e "TRANSMISSION_PEER_PORT_RANDOM_ON_START=false" \\
         -e "LOCAL_NETWORK=${LAN}" \\
         -e "PUID=${PUID}" \\
         -e "PGID=${PGID}" \\
@@ -835,6 +871,8 @@ else
     --env-file "${CONTAINER_DIR}/.env" \
     -e OPENVPN_PROVIDER=PIA \
     -e "OPENVPN_CONFIG=${PIA_REGION}" \
+    -e "DISABLE_PORT_UPDATER=true" \
+    -e "TRANSMISSION_PEER_PORT_RANDOM_ON_START=false" \
     -e "LOCAL_NETWORK=${LAN}" \
     -e "PUID=${PUID}" \
     -e "PGID=${PGID}" \

--- a/app-setup/templates/transmission-post-start.sh
+++ b/app-setup/templates/transmission-post-start.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+#
+# transmission-post-start.sh — PIA port forwarding with validation
+#
+# Replaces the port updater bundled in haugene/transmission-openvpn. The
+# container runs this automatically after Transmission starts, provided
+# DISABLE_PORT_UPDATER=true is set so the bundled updater stays out of the way.
+#
+# Why replace it rather than patch it: the bundled script lives at
+# /etc/openvpn/pia/update-port.sh inside the image, alongside the 167 .ovpn
+# region configs. Mounting over that directory to swap one file would hide the
+# configs and break region selection, and editing a file inside a running
+# container does not survive a recreate. /scripts is already bind-mounted and
+# the image documents /scripts/transmission-post-start.sh as a hook, so owning
+# the whole loop from here is both simpler and durable across image updates.
+#
+# The bug this exists to prevent (issue #159): on a getSignature failure the
+# bundled script logs a fatal error, carries on with an empty $pf_port, and
+# runs `transmission-remote -p ""`. That sets the listen port to 0, which stops
+# tracker announces and leaves magnet links unable to fetch metadata over DHT —
+# downloads stop entirely rather than merely running unforwarded. It then logs
+# "SUCCESS" with a blank port. Observed in production 2026-08-21 → 08-23.
+#
+# This version refuses to apply a port it cannot validate, leaving whatever
+# Transmission is already using in place.
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-08-23
+
+set -uo pipefail
+
+# Deliberately not `set -e`: this runs for the container's lifetime and a
+# transient curl failure must not kill the loop. Failures are handled where
+# they occur.
+
+# The image calls this hook SYNCHRONOUSLY:
+#
+#     /scripts/transmission-post-start.sh "${USER_SCRIPT_ARGS[@]}"
+#
+# with no trailing `&` — unlike the bundled updater, which it backgrounds
+# itself. Since this script runs a lifetime loop, returning control is our
+# responsibility: blocking here hangs the rest of the container's startup
+# chain, leaving the tunnel negotiated but passing no traffic at all.
+#
+# So re-exec ourselves detached and return immediately. PIA_PORT_DETACHED marks
+# the background copy so it does not fork again.
+# Output stays attached to the container log (fd 1/2 of PID 1) — discarding it
+# would leave an operator no way to see what the manager is doing.
+if [[ -z "${PIA_PORT_DETACHED:-}" ]]; then
+  PIA_PORT_DETACHED=1 setsid "$0" "$@" <&- &
+  exit 0
+fi
+
+GUARD_LIB="/scripts/pia-port-guard.sh"
+
+# PIA's next-generation port forwarding. 19999 is a convention from PIA's
+# reference implementation, not a value they advertise — their server list
+# publishes ports for every other service but none for forwarding. If PIA ever
+# moves it, this fails closed: the guard keeps the existing port rather than
+# zeroing it.
+PIA_TOKEN_URL="https://www.privateinternetaccess.com/gtoken/generateToken"
+PF_API_PORT=19999
+
+CURL_MAX_TIME=15
+CURL_RETRY=3
+CURL_RETRY_DELAY=10
+
+# How often to re-assert the reservation. PIA expires bindings that are not
+# refreshed; upstream uses the same 15-minute cadence.
+REFRESH_INTERVAL=900
+
+# Renew the token when the reservation has less than a week left, matching
+# upstream's threshold.
+TOKEN_MIN_REMAINING=$((60 * 60 * 24 * 7))
+
+log() {
+  local now
+  now="$(date '+%Y-%m-%d %H:%M:%S')"
+  printf '%s [pia-port] %s\n' "${now}" "$*"
+}
+
+# ---------------------------------------------------------------------------
+# Guard
+# ---------------------------------------------------------------------------
+
+if [[ ! -r "${GUARD_LIB}" ]]; then
+  log "FATAL: guard library missing at ${GUARD_LIB}"
+  log "Refusing to manage the peer port without validation — exiting."
+  log "Transmission keeps its configured port and runs unforwarded."
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "${GUARD_LIB}"
+
+# ---------------------------------------------------------------------------
+# Transmission connection details
+# ---------------------------------------------------------------------------
+
+TRANSMISSION_RPC_PORT="${TRANSMISSION_RPC_PORT:-9091}"
+if [[ -z "${TRANSMISSION_RPC_URL:-}" ]] && [[ -r /etc/transmission/default-settings.json ]]; then
+  TRANSMISSION_RPC_URL="$(jq -r '."rpc-url"' /etc/transmission/default-settings.json 2>/dev/null || echo /transmission/rpc)"
+fi
+TRANSMISSION_RPC_URL="${TRANSMISSION_RPC_URL:-/transmission/rpc}"
+
+# Trailing slash breaks transmission-remote's URL parsing.
+TRANSMISSION_HOST="http://localhost:${TRANSMISSION_RPC_PORT}${TRANSMISSION_RPC_URL%/}"
+
+# Auth is assembled as an array so it expands to zero or two arguments without
+# relying on word splitting.
+TR_AUTH=()
+TRANSMISSION_HOME="${TRANSMISSION_HOME:-/config/transmission-home}"
+SETTINGS_FILE="${TRANSMISSION_HOME}/settings.json"
+CREDS_FILE=/config/transmission-credentials.txt
+
+if [[ -r "${SETTINGS_FILE}" ]] \
+  && grep -q '"rpc-authentication-required"[[:space:]]*:[[:space:]]*true' "${SETTINGS_FILE}" 2>/dev/null; then
+  if [[ -r "${CREDS_FILE}" ]]; then
+    tr_user="$(head -1 "${CREDS_FILE}")"
+    tr_pass="$(tail -1 "${CREDS_FILE}")"
+    TR_AUTH=(--auth "${tr_user}:${tr_pass}")
+    log "Transmission RPC authentication enabled"
+  else
+    log "WARNING: RPC auth required but ${CREDS_FILE} is unreadable"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# PIA credentials
+# ---------------------------------------------------------------------------
+
+PIA_CREDS_FILE=/config/openvpn-credentials.txt
+if [[ ! -r "${PIA_CREDS_FILE}" ]]; then
+  log "FATAL: PIA credentials not readable at ${PIA_CREDS_FILE}"
+  exit 1
+fi
+pia_user="$(sed -n 1p "${PIA_CREDS_FILE}")"
+pia_pass="$(sed -n 2p "${PIA_CREDS_FILE}")"
+
+# ---------------------------------------------------------------------------
+# PIA port forwarding API
+# ---------------------------------------------------------------------------
+
+# Gateway that terminates the tunnel; the PF service answers here.
+pf_gateway() {
+  ip route 2>/dev/null | grep tun | grep -v src | head -1 | awk '{print $3}'
+}
+
+# Populates pf_token. Returns non-zero if PIA would not issue one.
+get_auth_token() {
+  local response
+  response="$(curl --silent --show-error --request POST \
+    --max-time "${CURL_MAX_TIME}" \
+    --user "${pia_user}:${pia_pass}" \
+    "${PIA_TOKEN_URL}" 2>/dev/null)" || {
+    log "Token request failed (network or auth)"
+    return 1
+  }
+
+  pf_token="$(jq -r '.token // empty' <<<"${response}" 2>/dev/null)"
+  [[ -n "${pf_token}" ]] || {
+    log "Token response contained no token"
+    return 1
+  }
+}
+
+# Populates pf_payload, pf_signature, pf_port, pf_token_expiry.
+#
+# The PF endpoint presents a certificate for a PIA hostname while we reach it
+# by gateway IP, so --insecure is required; the bearer token is what actually
+# authenticates the call.
+get_signature() {
+  local gateway response status
+  gateway="$(pf_gateway)"
+  [[ -n "${gateway}" ]] || {
+    log "No tunnel gateway — is the VPN up?"
+    return 1
+  }
+
+  response="$(curl --insecure --get --silent --show-error \
+    --retry "${CURL_RETRY}" --retry-delay "${CURL_RETRY_DELAY}" \
+    --max-time "${CURL_MAX_TIME}" \
+    --data-urlencode "token=${pf_token}" \
+    "https://${gateway}:${PF_API_PORT}/getSignature" 2>/dev/null)" || {
+    log "getSignature unreachable at ${gateway}:${PF_API_PORT}"
+    return 1
+  }
+
+  status="$(jq -r '.status // "unparseable"' <<<"${response}" 2>/dev/null)"
+  if [[ "${status}" != "OK" ]]; then
+    log "getSignature returned status '${status}' — region may not offer port forwarding"
+    return 1
+  fi
+
+  pf_payload="$(jq -r '.payload // empty' <<<"${response}" 2>/dev/null)"
+  pf_signature="$(jq -r '.signature // empty' <<<"${response}" 2>/dev/null)"
+  [[ -n "${pf_payload}" && -n "${pf_signature}" ]] || {
+    log "getSignature response missing payload or signature"
+    return 1
+  }
+
+  local decoded
+  decoded="$(base64 -d <<<"${pf_payload}" 2>/dev/null)" || {
+    log "Could not decode payload"
+    return 1
+  }
+
+  pf_port="$(jq -r '.port // empty' <<<"${decoded}" 2>/dev/null)"
+  local expiry_raw
+  expiry_raw="$(jq -r '.expires_at // empty' <<<"${decoded}" 2>/dev/null)"
+  pf_token_expiry="$(date --date="${expiry_raw}" +%s 2>/dev/null || echo 0)"
+}
+
+# Reserves (or re-asserts) the port PIA assigned. Must be repeated periodically
+# or PIA drops the binding.
+bind_port() {
+  local gateway response status
+  gateway="$(pf_gateway)"
+  [[ -n "${gateway}" ]] || return 1
+
+  response="$(curl --insecure --get --silent --show-error \
+    --retry "${CURL_RETRY}" --retry-delay "${CURL_RETRY_DELAY}" \
+    --max-time "${CURL_MAX_TIME}" \
+    --data-urlencode "payload=${pf_payload}" \
+    --data-urlencode "signature=${pf_signature}" \
+    "https://${gateway}:${PF_API_PORT}/bindPort" 2>/dev/null)" || {
+    log "bindPort unreachable"
+    return 1
+  }
+
+  status="$(jq -r '.status // "unparseable"' <<<"${response}" 2>/dev/null)"
+  [[ "${status}" == "OK" ]] || {
+    log "bindPort returned status '${status}'"
+    return 1
+  }
+}
+
+# Full acquisition: token, signature, reservation, then hand the port to the
+# guard. Returns non-zero if any step fails, leaving the peer port untouched.
+acquire_and_apply() {
+  get_auth_token || return 1
+  get_signature || return 1
+  bind_port || return 1
+
+  # apply_port refuses anything that isn't a valid port, so a malformed
+  # response can never reach transmission-remote.
+  apply_port "${pf_port}" "${TRANSMISSION_HOST}" "${TR_AUTH[@]}"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+pf_token=""
+pf_payload=""
+pf_signature=""
+pf_port=""
+pf_token_expiry=0
+
+log "Starting PIA port forwarding manager (region: ${OPENVPN_CONFIG:-unknown})"
+
+# Transmission has to be accepting RPC before a port can be set.
+until transmission-remote "${TRANSMISSION_HOST}" "${TR_AUTH[@]}" -si >/dev/null 2>&1; do
+  log "Waiting for Transmission RPC..."
+  sleep 10
+done
+log "Transmission is responsive"
+
+if acquire_and_apply; then
+  log "Port forwarding active on ${pf_port}"
+else
+  log "Could not obtain a forwarded port — continuing unforwarded."
+  log "Transmission keeps its existing peer port; downloads still work, but"
+  log "inbound peer connections will not."
+fi
+
+while true; do
+  sleep "${REFRESH_INTERVAL}" &
+  wait $!
+
+  now="$(date +%s)"
+  remaining=$((pf_token_expiry - now))
+
+  if [[ -z "${pf_payload}" ]] || [[ ${remaining} -lt ${TOKEN_MIN_REMAINING} ]]; then
+    # No active reservation, or the current one is close to expiry.
+    if [[ -n "${pf_payload}" ]]; then
+      log "Reservation expiring in $((remaining / 86400))d — renewing"
+    fi
+    if acquire_and_apply; then
+      log "Port forwarding renewed on ${pf_port}"
+    else
+      log "Renewal failed; will retry in $((REFRESH_INTERVAL / 60)) minutes"
+    fi
+    continue
+  fi
+
+  # Re-assert the existing reservation so PIA does not drop it.
+  if ! bind_port; then
+    log "Re-bind failed; will attempt a full renewal next cycle"
+    pf_payload=""
+  fi
+done

--- a/config/config.conf.template
+++ b/config/config.conf.template
@@ -59,8 +59,9 @@ USE_ITERM2="false"        # Set to "true" to copy complete iTerm2 preferences fr
 # VPN and Transmission configuration (optional)
 # Used by podman-transmission-setup.sh to configure the containerized Transmission stack
 ONEPASSWORD_PIA_ITEM=""          # 1Password item name holding PIA account credentials
-PIA_VPN_REGION="ca_toronto"      # PIA region for haugene (must match /etc/openvpn/pia/ stem, NOT the API region id)
+PIA_VPN_REGION="ca_vancouver"    # PIA region for haugene (must match /etc/openvpn/pia/ stem, NOT the API region id)
                                  # Must support port forwarding — panama advertises it but serves none (issue #159)
+                                 # Measured 2026-08-23: vancouver 14.6ms/17.2MB/s vs toronto 63.2ms/2.4MB/s
 LAN_SUBNET="192.168.1.0/24"      # Local network CIDR for Transmission web UI access
 TRANSMISSION_HOST_PORT="9091"    # Host port for Transmission web UI
 

--- a/docs/apps/pia-vpn-README.md
+++ b/docs/apps/pia-vpn-README.md
@@ -282,13 +282,48 @@ metadata over DHT, so downloads never start. The retry loop repeats this every
 This is strictly worse than doing nothing: an unforwarded Transmission on a
 valid port still downloads from seeders, just more slowly.
 
-[`app-setup/templates/pia-port-guard.sh`](../../app-setup/templates/pia-port-guard.sh)
-is the validation the upstream script lacks. Source it from a patched
-`update-port.sh` and call `apply_port`, which refuses empty, non-numeric,
-`null`, zero, privileged, and out-of-range values, leaving the existing port
-intact instead.
+### How this is fixed here
 
-Covered by `tests/pia-port-guard.bats`.
+The bundled updater cannot be patched in place: it lives at
+`/etc/openvpn/pia/update-port.sh` inside the image, alongside the 167 `.ovpn`
+region configs, so mounting over that directory to swap one file would hide
+the configs and break region selection.
+
+Instead `DISABLE_PORT_UPDATER=true` keeps it dormant, and
+[`transmission-post-start.sh`](../../app-setup/templates/transmission-post-start.sh)
+runs our own port-forwarding manager from the already-mounted `/scripts`
+volume. It performs the same token → getSignature → bindPort flow, but hands
+the result to
+[`pia-port-guard.sh`](../../app-setup/templates/pia-port-guard.sh), which
+refuses empty, non-numeric, `null`, zero, privileged, and out-of-range values
+and leaves the existing port intact instead.
+
+If the guard library is missing the manager exits rather than running
+unguarded — an unforwarded Transmission beats a zeroed one.
+
+Covered by `tests/pia-port-guard.bats` and
+`tests/transmission-post-start.bats`.
+
+#### Two container quirks worth knowing
+
+**The post-start hook is called synchronously.** The image backgrounds its own
+updater with `&` but invokes `/scripts/transmission-post-start.sh` inline. A
+hook that blocks — as any lifetime loop does — hangs the rest of the startup
+chain, leaving the tunnel negotiated but passing no traffic at all: DNS fails,
+`curl` to a bare IP fails, and `Transmission startup script complete` never
+appears in the log. The manager therefore backgrounds itself immediately and
+returns. Diagnose by counting that line:
+
+```bash
+sudo -u operator podman logs transmission-vpn | grep -c "startup script complete"
+# 0 means something in the startup chain is blocking
+```
+
+**Peer port randomization fights port forwarding.** The image defaults
+`peer-port-random-on-start` to true, which picks a random port at each start
+and silently replaces the one PIA assigned. `settings.json` and the running
+listen port then disagree. The setup script now pins
+`TRANSMISSION_PEER_PORT_RANDOM_ON_START=false`.
 
 ## Monitoring note
 

--- a/docs/apps/pia-vpn-README.md
+++ b/docs/apps/pia-vpn-README.md
@@ -204,8 +204,51 @@ point is that each region returned one.
 | `se_stockholm` | 43172 | 10.80.192.1 |
 
 `panama` — the region this server was pinned to until 2026-08-23 — remains the
-only one observed serving no port forwarding at all. **TILSIT now runs
-`ca_toronto`**, which reserved port 50454 on first connect and verified open.
+only one observed serving no port forwarding at all.
+
+### Region choice: measure, don't assume
+
+**TILSIT runs `ca_vancouver`**, the physically closest endpoint.
+
+Working port forwarding is a prerequisite, not a ranking. All eight regions
+above pass that test equally, and the probe deliberately says nothing about
+speed. Picking among them by intuition produced a bad answer once already:
+`ca_toronto` was chosen because it was first in a hand-written shortlist and
+its probe passed, then measured 4x slower on both metrics.
+
+Measured 2026-08-23, from TILSIT:
+
+| Region | Latency | Throughput (10 MB) |
+| --- | --- | --- |
+| `ca_vancouver` | **14.4 ms** | **8.6 MB/s** |
+| `ca_toronto` | 63.2 ms | 2.4 MB/s |
+
+Real-world effect on a well-seeded torrent was the same order: a control magnet
+that managed 278 kB/s on Toronto pulled 1.83 MB/s on Vancouver.
+
+To compare regions yourself, run a throwaway container on each and measure —
+the same flags the probe uses:
+
+```bash
+sudo -u operator podman run -d --name pia-lat-test \
+  --privileged --device /dev/net/tun:/dev/net/tun \
+  -e OPENVPN_PROVIDER=PIA -e OPENVPN_CONFIG=<region> \
+  -e OPENVPN_USERNAME=... -e OPENVPN_PASSWORD=... \
+  -e CREATE_TUN_DEVICE=false -e LOG_TO_STDOUT=true \
+  -e TRANSMISSION_DOWNLOAD_DIR=/tmp \
+  docker.io/haugene/transmission-openvpn:latest
+
+# then, once the tunnel is up:
+sudo -u operator podman exec pia-lat-test sh -c '
+  gw=$(ip route | grep tun | grep -v src | head -1 | awk "{print \$3}")
+  ping -c 20 -q "$gw" | tail -2
+  curl -s -o /dev/null -w "%{speed_download} B/s\n" \
+    https://speed.cloudflare.com/__down?bytes=10000000'
+```
+
+Automating this ranking is what issue #159 is for. Note the jurisdiction
+constraint recorded there: exclude US endpoints, rank everything else on
+measured performance.
 
 ### On the hardcoded PF port
 

--- a/tests/transmission-post-start.bats
+++ b/tests/transmission-post-start.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+#
+# Tests for transmission-post-start template — the PIA port forwarding manager
+# that replaces the image's bundled update-port.sh.
+#
+# The behaviour under test is what the bundled script got wrong (issue #159):
+# a port-forwarding failure must never reach transmission-remote as an empty
+# or malformed port, because that sets the listen port to 0 and stops magnet
+# links from resolving at all.
+#
+# Run with: bats tests/transmission-post-start.bats
+
+BATS_TEST_FILENAME="${BATS_TEST_FILENAME:-}"
+REPO_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+POST_START="${REPO_DIR}/app-setup/templates/transmission-post-start.sh"
+GUARD="${REPO_DIR}/app-setup/templates/pia-port-guard.sh"
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  export TEST_TMPDIR
+  export CALL_LOG="${TEST_TMPDIR}/calls.log"
+  touch "${CALL_LOG}"
+  export STUB_CURRENT_PORT="33361"
+
+  cat >"${TEST_TMPDIR}/transmission-remote" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CALL_LOG}"
+for arg in "$@"; do
+  if [[ "${arg}" == "-si" ]]; then
+    printf '  Listen port: %s\n' "${STUB_CURRENT_PORT}"
+    exit 0
+  fi
+done
+exit 0
+STUB
+  chmod +x "${TEST_TMPDIR}/transmission-remote"
+  export PATH="${TEST_TMPDIR}:${PATH}"
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+}
+
+# --- fail-closed on a missing guard ----------------------------------------
+
+@test "exits rather than managing the port when the guard library is absent" {
+  # Without validation the script must not touch the peer port at all —
+  # running unforwarded beats risking a zeroed port.
+  #
+  # Run the detached branch directly (PIA_PORT_DETACHED set), since the parent
+  # backgrounds itself and always returns 0.
+  local script="${TEST_TMPDIR}/post-start.sh"
+  sed 's|GUARD_LIB="/scripts/pia-port-guard.sh"|GUARD_LIB="/nonexistent/guard.sh"|' \
+    "${POST_START}" >"${script}"
+  chmod +x "${script}"
+
+  PIA_PORT_DETACHED=1 run timeout 10 bash "${script}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"guard library missing"* ]]
+  [[ "$output" == *"Refusing to manage the peer port"* ]]
+}
+
+@test "does not invoke transmission-remote when the guard is absent" {
+  local script="${TEST_TMPDIR}/post-start.sh"
+  sed 's|GUARD_LIB="/scripts/pia-port-guard.sh"|GUARD_LIB="/nonexistent/guard.sh"|' \
+    "${POST_START}" >"${script}"
+  chmod +x "${script}"
+
+  PIA_PORT_DETACHED=1 run timeout 10 bash "${script}"
+  [ ! -s "${CALL_LOG}" ]
+}
+
+# --- guard integration ------------------------------------------------------
+
+@test "the guard rejects every port the API could plausibly return as broken" {
+  # shellcheck source=/dev/null
+  source "${GUARD}"
+
+  local bad
+  for bad in "" "null" "0" "abc" "   " "80" "65536"; do
+    run apply_port "${bad}" "http://localhost:9091/transmission/rpc"
+    [ "$status" -ne 0 ]
+  done
+
+  # Nothing above should have reached transmission-remote with -p.
+  ! grep -q -- " -p " "${CALL_LOG}"
+}
+
+@test "the guard applies a well-formed port" {
+  # shellcheck source=/dev/null
+  source "${GUARD}"
+
+  run apply_port 50454 "http://localhost:9091/transmission/rpc"
+  [ "$status" -eq 0 ]
+  grep -q -- "-p 50454" "${CALL_LOG}"
+}
+
+# --- static checks ----------------------------------------------------------
+
+@test "sources the guard before defining any port-applying logic" {
+  # A regression here would mean the script could call apply_port without the
+  # guard having been loaded.
+  local guard_line apply_line
+  guard_line="$(grep -n 'source "${GUARD_LIB}"' "${POST_START}" | cut -d: -f1)"
+  apply_line="$(grep -n 'apply_port "\${pf_port}"' "${POST_START}" | cut -d: -f1)"
+  [ -n "${guard_line}" ]
+  [ -n "${apply_line}" ]
+  [ "${guard_line}" -lt "${apply_line}" ]
+}
+
+@test "never calls transmission-remote -p outside the guard" {
+  # The whole point is that the guard is the only path to setting the port.
+  # Comments are stripped first: the header quotes the upstream bug verbatim.
+  run bash -c "grep -vE '^[[:space:]]*#' '${POST_START}' | grep -nE 'transmission-remote.*-p '"
+  [ "$status" -ne 0 ]
+}
+
+@test "acquire_and_apply aborts before apply_port when a step fails" {
+  # Each API step must short-circuit, so a failure can't fall through to
+  # applying an unset pf_port.
+  run grep -cE '^\s*(get_auth_token|get_signature|bind_port) \|\| return 1' "${POST_START}"
+  [ "$output" -eq 3 ]
+}
+
+@test "does not use set -e, which would kill the long-running loop" {
+  run grep -E '^set -euo pipefail' "${POST_START}"
+  [ "$status" -ne 0 ]
+  run grep -E '^set -uo pipefail' "${POST_START}"
+  [ "$status" -eq 0 ]
+}
+
+# --- non-blocking startup ---------------------------------------------------
+
+@test "returns immediately instead of blocking the container startup chain" {
+  # The image calls this hook synchronously, with no trailing `&`. A blocking
+  # loop here hangs the rest of startup and leaves the tunnel passing no
+  # traffic — observed in production 2026-08-23.
+  local script="${TEST_TMPDIR}/post-start.sh"
+  sed -e 's|GUARD_LIB="/scripts/pia-port-guard.sh"|GUARD_LIB="/nonexistent/guard.sh"|' \
+    "${POST_START}" >"${script}"
+  chmod +x "${script}"
+
+  # Without self-backgrounding this hits the timeout instead of returning.
+  run timeout 8 bash "${script}"
+  [ "$status" -eq 0 ]
+}
+
+@test "detached output stays attached to the container log" {
+  # nohup >/dev/null would hide every message the manager emits.
+  run grep -E 'setsid .* >/dev/null' "${POST_START}"
+  [ "$status" -ne 0 ]
+}
+
+@test "the detached copy does not fork again" {
+  run grep -c 'PIA_PORT_DETACHED' "${POST_START}"
+  [ "$output" -ge 2 ]
+  run grep -E 'PIA_PORT_DETACHED=1 setsid' "${POST_START}"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Two changes

**1. The guard is finally wired in.** It shipped in #172 as a library nothing
called, so the destructive path was still live: on a PF failure the bundled
`update-port.sh` pushes an empty port into Transmission, zeroing the listen
port and stopping magnet links entirely.

**2. Region moves to `ca_vancouver`** on measured performance rather than a
guess.

## Why replace the updater instead of patching it

The bundled script can't be patched. It lives at
`/etc/openvpn/pia/update-port.sh` inside the image, alongside the 167 `.ovpn`
region configs — mounting over that directory to swap one file would hide the
configs and break region selection entirely.

Instead `DISABLE_PORT_UPDATER=true` keeps it dormant while our manager runs
from the already-mounted `/scripts` volume, doing the same token →
getSignature → bindPort flow but routing the result through the guard. If the
guard library is missing it exits rather than running unguarded — unforwarded
beats zeroed.

## Three bugs only deployment could have caught

**The post-start hook is invoked synchronously.** The image backgrounds its own
updater with `&` but calls `/scripts/transmission-post-start.sh` inline. A
lifetime loop there hangs the entire startup chain: the tunnel negotiates but
carries no traffic at all, DNS fails, and `Transmission startup script
complete` never appears. It logged **0 times** before the fix and **1** after.
The manager now backgrounds itself and returns immediately.

**`nohup >/dev/null` discarded every message the manager emitted**, leaving no
way to see what it was doing. Switched to `setsid` so output reaches the
container log.

**`peer-port-random-on-start` defaults true in the image**, picking a random
port at each start and silently replacing the one PIA assigned — `settings.json`
and the running listen port disagreed as a result. Now pinned false.

## Region: measured, not guessed

`ca_toronto` was picked because it was first in a hand-written shortlist and
its probe passed. The probe only answers *whether port forwarding works* — all
eight surveyed regions pass equally — so it was never evidence about speed.

Measured from TILSIT:

| Region | Latency | Throughput (10 MB) |
| --- | --- | --- |
| `ca_vancouver` | **14.4 ms** | **8.6 MB/s** |
| `ca_toronto` | 63.2 ms | 2.4 MB/s |

Vancouver is also the physically closest endpoint. A control magnet that pulled
278 kB/s on Toronto managed 1.83 MB/s on Vancouver.

The README now carries the numbers and the commands to reproduce them, so the
next region change is a measurement rather than another guess.

## Verified in production

```
[pia-port] Port forwarding active on 23595
Listen port: 23595    Port is open: Yes
OPENVPN_CONFIG=ca_vancouver
DISABLE_PORT_UPDATER=true
TRANSMISSION_PEER_PORT_RANDOM_ON_START=false
```

Container healthy; a control magnet resolved metadata and downloaded normally.

## Testing

11 new BATS tests covering the fail-closed path (no guard → exit, never touch
the port), every value the API could plausibly return as broken, and the
non-blocking startup regression. Full suite passing, shellcheck `-S info` and
shfmt clean.

## Not here

Automated region ranking stays on #159, along with the jurisdiction constraint
(exclude US, rank the rest on measured performance) and PIA upstream drift
detection.

Refs #159
