### PR TITLE
fix(pia,podman): port-forwarding watchdog, bounded podman calls, honest gateway logging

### DIFF
--- a/app-setup/podman-transmission-setup.sh
+++ b/app-setup/podman-transmission-setup.sh
@@ -559,6 +559,96 @@ log_ts() {
     echo "[\${ts}] \$*"
 }
 
+# Every podman call in this script goes through podman_t (issue #168).
+#
+# On 2026-08-16 a routine VirtioFS recovery issued \`podman run -d\` through a
+# freshly Homebrew-upgraded 6.1.0 CLI while a leftover 6.0.2 gvproxy still held
+# the machine's socket paths. That podman run hung indefinitely — it was still
+# running 27 hours later. Because this supervision loop is single-threaded and
+# calls ensure_container synchronously, the hang froze the whole loop: no
+# further log lines, no container, nothing listening on the web UI port, and no
+# self-recovery, which is precisely what the loop exists to provide.
+#
+# A hung subprocess must never be able to do that again. Any podman invocation
+# that exceeds its timeout is killed and reported as a distinct failure, which
+# the callers treat like any other failure: retry next cycle.
+PODMAN_CMD_TIMEOUT=\${PODMAN_CMD_TIMEOUT:-60}
+PODMAN_MACHINE_TIMEOUT=\${PODMAN_MACHINE_TIMEOUT:-180}
+
+# timeout(1) exits 124 when it had to kill the command.
+TIMEOUT_RC=124
+
+# timeout(1) comes from coreutils, which config/formulae.txt installs, and it
+# is required rather than optional. Two considered fallbacks were rejected:
+#
+#   - Running unbounded when it is missing reintroduces exactly the hang this
+#     section exists to prevent, and does so silently.
+#   - perl's \`alarm shift; exec @ARGV\` does not work here. SIGALRM kills the
+#     perl process but leaves the command's own children running, so they hold
+#     the command-substitution pipe open and \`state=\$(podman_t ... inspect)\`
+#     blocks forever anyway — the original bug, wearing a timeout.
+#
+# So: fail loudly at startup instead of supervising with a supervision loop
+# that cannot actually recover.
+if ! command -v timeout >/dev/null 2>&1; then
+    log_ts "FATAL: timeout(1) not found on PATH."
+    log_ts "It is required to bound podman calls; without it a hung podman"
+    log_ts "command freezes this supervision loop indefinitely (issue #168)."
+    log_ts "Install it with: brew install coreutils"
+    exit 1
+fi
+
+# Run podman under a timeout. First argument is the timeout in seconds.
+# A timeout is logged distinctly from an ordinary non-zero exit so an operator
+# reading the log can tell a hang from a failure — not being able to make that
+# distinction is what let the August outage run for 27 hours.
+podman_t() {
+    local limit="\$1"
+    shift
+    # Just the subcommand for the log. \`podman run\` carries forty-odd flags and
+    # printing all of them buries the one fact that matters.
+    local what="\$1 \${2:-}"
+    local rc=0
+    # --kill-after: if podman ignores SIGTERM, SIGKILL follows. Without it a
+    # podman that traps TERM keeps the pipe open and the loop stays stuck.
+    timeout --kill-after=10 "\${limit}" podman "\$@" || rc=\$?
+    if [[ \${rc} -eq \${TIMEOUT_RC} ]]; then
+        log_ts "TIMEOUT: 'podman \${what}' exceeded \${limit}s and was killed"
+    fi
+    return \${rc}
+}
+
+# \`podman machine stop\` returning 0 does not mean the machine's helper
+# processes are gone. The 6.0.2 gvproxy orphaned by the August incident was
+# still running 7 days after the upgrade, holding the socket paths the new CLI
+# then tried to reuse. Verify the processes actually exited, and kill whatever
+# is left before anything tries to start the machine again.
+reap_machine_helpers() {
+    local pids
+    # Match on the machine name, which appears in both helpers' socket paths
+    # (transmission-vm-gvproxy.sock, transmission-vm-api.sock).
+    pids=\$(pgrep -f 'gvproxy|vfkit' 2>/dev/null | while read -r pid; do
+        if ps -o args= -p "\${pid}" 2>/dev/null | grep -q 'transmission-vm'; then
+            echo "\${pid}"
+        fi
+    done)
+
+    [[ -n "\${pids}" ]] || return 0
+
+    log_ts "stale machine helpers still running after stop: \${pids//\$'\\n'/ }"
+    local pid
+    for pid in \${pids}; do
+        kill "\${pid}" 2>/dev/null || true
+    done
+    sleep 3
+    for pid in \${pids}; do
+        if kill -0 "\${pid}" 2>/dev/null; then
+            log_ts "helper \${pid} ignored SIGTERM — sending SIGKILL"
+            kill -9 "\${pid}" 2>/dev/null || true
+        fi
+    done
+}
+
 wait_for_nfs() {
     local mount_point="${NFS_MOUNT_POINT}"
     local max_wait=120
@@ -577,13 +667,17 @@ wait_for_nfs() {
 
 ensure_machine() {
     local state
-    state=\$(podman machine inspect transmission-vm --format '{{.State}}' 2>/dev/null || echo unknown)
+    state=\$(podman_t "\${PODMAN_CMD_TIMEOUT}" machine inspect transmission-vm --format '{{.State}}' 2>/dev/null || echo unknown)
     if [[ "\${state}" != "running" ]]; then
         log_ts "machine state=\${state}, starting transmission-vm"
-        podman machine start transmission-vm || return 1
+        # A machine that is not running may still have orphaned helpers holding
+        # its sockets — that is exactly the state the August incident started
+        # from. Clear them before asking podman to start it.
+        reap_machine_helpers
+        podman_t "\${PODMAN_MACHINE_TIMEOUT}" machine start transmission-vm || return 1
     fi
     for _ in {1..30}; do
-        if podman info >/dev/null 2>&1; then
+        if podman_t "\${PODMAN_CMD_TIMEOUT}" info >/dev/null 2>&1; then
             return 0
         fi
         sleep 1
@@ -594,15 +688,15 @@ ensure_machine() {
 
 ensure_container() {
     local running=false
-    if podman container exists transmission-vpn 2>/dev/null; then
-        running=\$(podman inspect transmission-vpn --format '{{.State.Running}}' 2>/dev/null || echo false)
+    if podman_t "\${PODMAN_CMD_TIMEOUT}" container exists transmission-vpn 2>/dev/null; then
+        running=\$(podman_t "\${PODMAN_CMD_TIMEOUT}" inspect transmission-vpn --format '{{.State.Running}}' 2>/dev/null || echo false)
     fi
     if [[ "\${running}" == "true" ]]; then
         return 0
     fi
     log_ts "container transmission-vpn not running — (re)creating"
-    podman rm -f transmission-vpn >/dev/null 2>&1 || true
-    podman run -d \\
+    podman_t "\${PODMAN_CMD_TIMEOUT}" rm -f transmission-vpn >/dev/null 2>&1 || true
+    podman_t "\${PODMAN_MACHINE_TIMEOUT}" run -d \\
         --name transmission-vpn \\
         --privileged \\
         --device /dev/net/tun:/dev/net/tun \\
@@ -647,15 +741,18 @@ DATA_CHECK_FAILURES=0
 MAX_DATA_FAILURES=3
 
 check_data_access() {
-    if ! podman exec transmission-vpn ls /data/ >/dev/null 2>&1; then
+    if ! podman_t "\${PODMAN_CMD_TIMEOUT}" exec transmission-vpn ls /data/ >/dev/null 2>&1; then
         DATA_CHECK_FAILURES=\$((DATA_CHECK_FAILURES + 1))
         log_ts "WARNING: /data/ inaccessible inside container (failure \${DATA_CHECK_FAILURES}/\${MAX_DATA_FAILURES})"
         if (( DATA_CHECK_FAILURES >= MAX_DATA_FAILURES )); then
             log_ts "RECOVERY: cycling VM to refresh VirtioFS NFS handles"
-            podman stop transmission-vpn 2>/dev/null || true
-            podman rm -f transmission-vpn 2>/dev/null || true
-            podman machine stop transmission-vm 2>/dev/null || true
+            podman_t "\${PODMAN_CMD_TIMEOUT}" stop transmission-vpn 2>/dev/null || true
+            podman_t "\${PODMAN_CMD_TIMEOUT}" rm -f transmission-vpn 2>/dev/null || true
+            podman_t "\${PODMAN_MACHINE_TIMEOUT}" machine stop transmission-vm 2>/dev/null || true
             sleep 5
+            # A clean exit status from machine stop is not proof the helpers
+            # exited; confirm before restarting into the same socket paths.
+            reap_machine_helpers
             if ensure_machine && ensure_container; then
                 log_ts "RECOVERY: VM and container restarted successfully"
             else
@@ -673,8 +770,15 @@ check_data_access() {
 }
 
 wait_for_nfs || exit 1
-ensure_machine
-ensure_container
+
+# Check these on the way in rather than pressing on regardless. A failed
+# machine start followed by an attempted container create produces a confusing
+# log — the container error looks like the problem when the machine was.
+if ensure_machine; then
+    ensure_container || log_ts "initial ensure_container failed — supervision loop will retry"
+else
+    log_ts "initial ensure_machine failed — supervision loop will retry"
+fi
 
 log_ts "entering supervision loop (interval=\${SUPERVISE_INTERVAL}s)"
 while true; do

--- a/app-setup/podman-transmission-setup.sh
+++ b/app-setup/podman-transmission-setup.sh
@@ -451,10 +451,21 @@ PORT_GUARD_DEST="${CONTAINER_DIR}/scripts/pia-port-guard.sh"
 POST_START_TEMPLATE="${SCRIPT_DIR}/templates/transmission-post-start.sh"
 POST_START_DEST="${CONTAINER_DIR}/scripts/transmission-post-start.sh"
 
+# The region survey runs on the host, not in the container, but it belongs with
+# the scripts it diagnoses and it needs the same .env credentials, which live
+# one directory up. Deploying it matters: the port watchdog's alert email and
+# the PIA README both tell an operator to run it when port forwarding is lost,
+# and until now nothing put it anywhere the operator account could reach — the
+# only copy was in the repo checkout, which operator does not have.
+PF_PROBE_TEMPLATE="${SCRIPT_DIR}/templates/pia-pf-probe.sh"
+PF_PROBE_DEST="${CONTAINER_DIR}/scripts/pia-pf-probe.sh"
+
 if [[ ! -f "${PORT_GUARD_TEMPLATE}" ]]; then
   collect_error "Template not found: ${PORT_GUARD_TEMPLATE}"
 elif [[ ! -f "${POST_START_TEMPLATE}" ]]; then
   collect_error "Template not found: ${POST_START_TEMPLATE}"
+elif [[ ! -f "${PF_PROBE_TEMPLATE}" ]]; then
+  collect_error "Template not found: ${PF_PROBE_TEMPLATE}"
 else
   # The guard is sourced, not executed, so it does not need the execute bit.
   sudo cp "${PORT_GUARD_TEMPLATE}" "${PORT_GUARD_DEST}"
@@ -465,7 +476,11 @@ else
   sudo chmod 755 "${POST_START_DEST}"
   sudo chown "${OPERATOR_USERNAME}:staff" "${POST_START_DEST}"
 
-  log "✅ PIA port forwarding manager deployed (guard + post-start hook)"
+  sudo cp "${PF_PROBE_TEMPLATE}" "${PF_PROBE_DEST}"
+  sudo chmod 755 "${PF_PROBE_DEST}"
+  sudo chown "${OPERATOR_USERNAME}:staff" "${PF_PROBE_DEST}"
+
+  log "✅ PIA port forwarding manager deployed (guard + post-start hook + region probe)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/app-setup/podman-transmission-setup.sh
+++ b/app-setup/podman-transmission-setup.sh
@@ -81,6 +81,16 @@ fi
 # shellcheck source=config/config.conf
 source "${CONFIG_FILE}"
 
+# SERVER_NAME comes from the sourced config. Validate it before deriving
+# anything: SERVER_NAME_LOWER names the keychain service the PIA credentials
+# are stored under, so an empty value would look up "pia-account-" and report a
+# missing-credentials error that points nowhere near the real cause.
+SERVER_NAME="${SERVER_NAME:-}"
+if [[ -z "${SERVER_NAME}" ]]; then
+  echo "❌ SERVER_NAME not set in ${CONFIG_FILE}"
+  exit 1
+fi
+
 SERVER_NAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${SERVER_NAME}")"
 HOSTNAME="${HOSTNAME_OVERRIDE:-${SERVER_NAME}}"
 HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${HOSTNAME}")"
@@ -233,8 +243,11 @@ if [[ -z "${OPERATOR_USERNAME}" ]]; then
   exit 1
 fi
 
-# PIA_VPN_REGION and LAN_SUBNET default gracefully if missing from config
-PIA_REGION="${PIA_VPN_REGION:-panama}"
+# PIA_VPN_REGION and LAN_SUBNET default gracefully if missing from config.
+# The PIA_VPN_REGION fallback must stay in step with config.conf.template:
+# panama (the pre-2026-08-23 default) serves no port forwarding at all, so
+# falling back to it would silently deploy a non-working region.
+PIA_REGION="${PIA_VPN_REGION:-ca_vancouver}"
 LAN="${LAN_SUBNET:-192.168.1.0/24}"
 HOST_PORT="${TRANSMISSION_HOST_PORT:-9091}"
 

--- a/app-setup/podman-transmission-setup.sh
+++ b/app-setup/podman-transmission-setup.sh
@@ -518,6 +518,46 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Section 7b: Deploy PIA port forwarding watchdog
+# ---------------------------------------------------------------------------
+
+set_section "Deploy PIA Port Watchdog"
+
+PORT_WATCHDOG_TEMPLATE="${SCRIPT_DIR}/templates/pia-port-watchdog.sh"
+PORT_WATCHDOG_DEST="${OPERATOR_HOME}/.local/bin/pia-port-watchdog.sh"
+PORT_WATCHDOG_MSMTP="${OPERATOR_HOME}/.config/msmtp/config"
+
+# The watchdog alerts by email, so it needs both a destination address and a
+# configured msmtp. Neither is set up by this script — msmtp-setup.sh owns
+# that — so skip rather than deploying an agent that can only log failures to
+# send mail. This script also runs unattended, so prompting is not an option.
+PORT_WATCHDOG_DEPLOY=true
+if [[ -z "${MONITORING_EMAIL:-}" ]] || [[ "${MONITORING_EMAIL}" == "your-email@example.com" ]]; then
+  log "⏭️  Skipping PIA port watchdog: MONITORING_EMAIL not configured in ${CONFIG_FILE}"
+  PORT_WATCHDOG_DEPLOY=false
+elif [[ ! -f "${PORT_WATCHDOG_MSMTP}" ]]; then
+  log "⏭️  Skipping PIA port watchdog: msmtp not configured. Run msmtp-setup.sh, then re-run this script."
+  PORT_WATCHDOG_DEPLOY=false
+elif [[ ! -f "${PORT_WATCHDOG_TEMPLATE}" ]]; then
+  collect_error "PIA port watchdog template not found: ${PORT_WATCHDOG_TEMPLATE}"
+  PORT_WATCHDOG_DEPLOY=false
+fi
+
+if [[ "${PORT_WATCHDOG_DEPLOY}" == "true" ]]; then
+  log "Deploying pia-port-watchdog.sh"
+
+  sudo sed \
+    -e "s|__SERVER_NAME__|${HOSTNAME}|g" \
+    -e "s|__MONITORING_EMAIL__|${MONITORING_EMAIL}|g" \
+    -e "s|__TRANSMISSION_HOST_PORT__|${HOST_PORT}|g" \
+    "${PORT_WATCHDOG_TEMPLATE}" | sudo tee "${PORT_WATCHDOG_DEST}" >/dev/null
+
+  sudo chown "${OPERATOR_USERNAME}:staff" "${PORT_WATCHDOG_DEST}"
+  sudo chmod 755 "${PORT_WATCHDOG_DEST}"
+  log "✅ pia-port-watchdog.sh deployed"
+fi
+
+# ---------------------------------------------------------------------------
 # Section 8: Deploy podman-machine-start.sh wrapper
 # ---------------------------------------------------------------------------
 
@@ -923,6 +963,50 @@ if sudo plutil -lint "${CLEANUP_PLIST}" >/dev/null 2>&1; then
   log "✅ pending-move-cleanup LaunchAgent created (hourly)"
 else
   collect_error "Invalid plist syntax in ${CLEANUP_PLIST}"
+fi
+
+# --- 9d: PIA port forwarding watchdog timer ---
+
+if [[ "${PORT_WATCHDOG_DEPLOY}" == "true" ]]; then
+  PORT_WATCHDOG_PLIST="${LAUNCHAGENT_DIR}/com.${HOSTNAME_LOWER}.pia-port-watchdog.plist"
+  log "Creating LaunchAgent: ${PORT_WATCHDOG_PLIST}"
+
+  # 15 minutes matches the port forwarding manager's own refresh cadence, so a
+  # loss is noticed within roughly one refresh cycle. With the 3-poll threshold
+  # that is a 45-minute worst case before alerting — against the 47 hours the
+  # August outage went unnoticed.
+  sudo -iu "${OPERATOR_USERNAME}" tee "${PORT_WATCHDOG_PLIST}" >/dev/null <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.${HOSTNAME_LOWER}.pia-port-watchdog</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>${OPERATOR_HOME}/.local/bin/pia-port-watchdog.sh</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>900</integer>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>${OPERATOR_HOME}/.local/state/${HOSTNAME_LOWER}-pia-port-watchdog.log</string>
+  <key>StandardErrorPath</key>
+  <string>${OPERATOR_HOME}/.local/state/${HOSTNAME_LOWER}-pia-port-watchdog.log</string>
+</dict>
+</plist>
+PLIST
+
+  sudo chown "${OPERATOR_USERNAME}:staff" "${PORT_WATCHDOG_PLIST}"
+  sudo chmod 644 "${PORT_WATCHDOG_PLIST}"
+
+  if sudo plutil -lint "${PORT_WATCHDOG_PLIST}" >/dev/null 2>&1; then
+    log "✅ pia-port-watchdog LaunchAgent created (every 15 minutes)"
+  else
+    collect_error "Invalid plist syntax in ${PORT_WATCHDOG_PLIST}"
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/app-setup/templates/pia-pf-probe.sh
+++ b/app-setup/templates/pia-pf-probe.sh
@@ -302,6 +302,13 @@ main() {
     log "Fetching regions advertising port_forward=true..."
     local region_list
     region_list="$(list_pf_regions)"
+    # A here-string always supplies a trailing newline, so mapfile on an empty
+    # region_list yields regions=("") — one empty element, not an empty array.
+    # The "no regions to probe" guard below counts that as 1 and the loop then
+    # probes the empty region name, emitting a confusing container_failed row.
+    if [[ -z "${region_list}" ]]; then
+      die "No regions advertising port_forward=true — PIA server list may be unavailable"
+    fi
     mapfile -t regions <<<"${region_list}"
     log "${#regions[@]} candidate regions"
   elif [[ ${#regions[@]} -eq 0 ]]; then

--- a/app-setup/templates/pia-port-watchdog.sh
+++ b/app-setup/templates/pia-port-watchdog.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+#
+# pia-port-watchdog.sh — alert when PIA port forwarding is lost
+#
+# Port-forwarding loss is invisible to anything that watches download activity,
+# because downloads keep working without it. Transmission still connects
+# outbound to peers that accept inbound connections, so well-seeded torrents
+# proceed — slower, and only to the reachable subset of the swarm.
+#
+# What actually breaks is quieter: with no peer port, tracker announces fail and
+# magnet links cannot retrieve metadata over DHT, so *newly added* torrents never
+# start. Existing ones look fine. Port forwarding was dead from 2026-08-21
+# through 08-23 — about 47 hours — and was only noticed when a freshly added
+# magnet sat at 0% and someone went looking (issue #181).
+#
+# The port guard added in #180 stops a PF failure from zeroing the peer port,
+# which is what turned that outage from "degraded" into "downloads stopped".
+# It deliberately fails soft: on PF failure it keeps the existing port and
+# carries on unforwarded. That is the right behaviour, and it means the system
+# now degrades silently. This watchdog is the missing signal.
+#
+# Each invocation is a single poll cycle: fetch, compare, alert, exit — the
+# same shape as plex-watchdog.sh, driven by a LaunchAgent.
+#
+# Template placeholders (replaced by podman-transmission-setup.sh at deploy time):
+#   __SERVER_NAME__              → server hostname for logging (e.g. TILSIT)
+#   __MONITORING_EMAIL__         → destination email address
+#   __TRANSMISSION_HOST_PORT__   → Transmission RPC port (e.g. 9091)
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-08-24
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SERVER_NAME="__SERVER_NAME__"
+MONITORING_EMAIL="__MONITORING_EMAIL__"
+HOSTNAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<<"${SERVER_NAME}")"
+
+TRANSMISSION_RPC_URL="http://localhost:__TRANSMISSION_HOST_PORT__/transmission/rpc"
+
+STATE_DIR="${HOME}/.config/pia-port-watchdog"
+STATE_FILE="${STATE_DIR}/state.json"
+MSMTP_CONFIG="${HOME}/.config/msmtp/config"
+LOG_FILE="${HOME}/.local/state/${HOSTNAME_LOWER}-pia-port-watchdog.log"
+
+# The peer port legitimately reads 0 for a few seconds during a container
+# restart or a region change. Require several consecutive bad polls before
+# alerting so a routine restart does not page anyone.
+CONSECUTIVE_FAILURE_THRESHOLD=3
+
+# Log that everything is fine once an hour rather than every cycle, matching
+# plex-watchdog's drift-vs-heartbeat cadence.
+HEARTBEAT_INTERVAL_SECONDS=3600
+
+CURL_MAX_TIME=15
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+log() {
+  local timestamp
+  timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  printf '[%s] [pia-port-watchdog] %s\n' "${timestamp}" "$1" >>"${LOG_FILE}"
+}
+
+# ---------------------------------------------------------------------------
+# State (atomic write via temp+mv, as plex-watchdog does)
+# ---------------------------------------------------------------------------
+
+read_state() {
+  if [[ -f "${STATE_FILE}" ]]; then
+    cat "${STATE_FILE}"
+  else
+    echo '{}'
+  fi
+}
+
+write_state() {
+  local state="$1"
+  local tmp="${STATE_FILE}.tmp.$$"
+  printf '%s\n' "${state}" >"${tmp}"
+  mv "${tmp}" "${STATE_FILE}"
+}
+
+state_get() {
+  local key="$1"
+  local default="${2:-}"
+  local val
+  val=$(read_state | jq -r ".${key} // empty" 2>/dev/null) || true
+  printf '%s' "${val:-${default}}"
+}
+
+# ---------------------------------------------------------------------------
+# Transmission RPC
+#
+# RPC auth is disabled on localhost (TRANSMISSION_RPC_AUTHENTICATION_REQUIRED
+# is false), so no credentials are needed. Transmission answers the first
+# request with 409 and a CSRF token, which every later request must echo back —
+# the same handshake pending-move-cleanup.sh performs.
+# ---------------------------------------------------------------------------
+
+rpc_session_id() {
+  curl -s -D - --max-time "${CURL_MAX_TIME}" "${TRANSMISSION_RPC_URL}" 2>/dev/null \
+    | awk 'tolower($0) ~ /^x-transmission-session-id:/{gsub(/\r/,""); print $2; exit}'
+}
+
+# Print the configured peer port, or nothing if the RPC could not be read.
+# Returns non-zero when Transmission is unreachable, which is deliberately
+# distinct from "reachable and reporting port 0".
+peer_port() {
+  local session_id
+  session_id="$(rpc_session_id)"
+  [[ -n "${session_id}" ]] || return 1
+
+  local response
+  response="$(curl -s --max-time "${CURL_MAX_TIME}" "${TRANSMISSION_RPC_URL}" \
+    -H "X-Transmission-Session-Id: ${session_id}" \
+    --data-raw '{"method":"session-get","arguments":{"fields":["peer-port"]}}' \
+    2>/dev/null)" || return 1
+
+  [[ "${response}" == *'"result":"success"'* ]] || return 1
+
+  local port
+  port="$(jq -r '.arguments["peer-port"] // empty' <<<"${response}" 2>/dev/null)" || return 1
+  [[ -n "${port}" ]] || return 1
+
+  printf '%s' "${port}"
+}
+
+# Ask Transmission whether its peer port is actually reachable from outside.
+# Prints "yes", "no", or "unknown" — a non-zero port can still be unforwarded,
+# which is exactly the state that went unnoticed for 47 hours.
+port_is_open() {
+  local session_id
+  session_id="$(rpc_session_id)"
+  [[ -n "${session_id}" ]] || {
+    printf 'unknown'
+    return 0
+  }
+
+  local response
+  response="$(curl -s --max-time "${CURL_MAX_TIME}" "${TRANSMISSION_RPC_URL}" \
+    -H "X-Transmission-Session-Id: ${session_id}" \
+    --data-raw '{"method":"port-test"}' 2>/dev/null)" || {
+    printf 'unknown'
+    return 0
+  }
+
+  # NOT `// "unknown"`. jq's alternative operator fires on false as well as
+  # null, so `.arguments["port-is-open"] // "unknown"` turns a genuine
+  # "port is closed" into "unknown" — silently discarding the single most
+  # important reading this watchdog takes. Test for presence explicitly.
+  local raw
+  raw="$(jq -r 'if has("arguments") and (.arguments | has("port-is-open"))
+                then .arguments["port-is-open"] | tostring
+                else "unknown" end' <<<"${response}" 2>/dev/null)" || {
+    printf 'unknown'
+    return 0
+  }
+
+  case "${raw}" in
+    true) printf 'yes' ;;
+    false) printf 'no' ;;
+    *) printf 'unknown' ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Email
+# ---------------------------------------------------------------------------
+
+send_email() {
+  local subject="$1"
+  local body="$2"
+
+  if [[ ! -f "${MSMTP_CONFIG}" ]]; then
+    log "ERROR: msmtp config not found at ${MSMTP_CONFIG} — cannot send email"
+    return 1
+  fi
+
+  printf 'Subject: %s\nTo: %s\n\n%s\n' "${subject}" "${MONITORING_EMAIL}" "${body}" \
+    | msmtp -C "${MSMTP_CONFIG}" "${MONITORING_EMAIL}" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat
+# ---------------------------------------------------------------------------
+
+maybe_heartbeat() {
+  local detail="$1"
+
+  local last_heartbeat
+  last_heartbeat=$(state_get "last_heartbeat" "1970-01-01T00:00:00Z")
+
+  local now_epoch last_epoch
+  now_epoch=$(date +%s)
+  last_epoch=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "${last_heartbeat}" '+%s' 2>/dev/null) || last_epoch=0
+
+  if [[ $((now_epoch - last_epoch)) -ge ${HEARTBEAT_INTERVAL_SECONDS} ]]; then
+    log "OK: ${detail}"
+    local now state
+    now=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+    state=$(read_state | jq --arg lh "${now}" '.last_heartbeat = $lh')
+    write_state "${state}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main poll cycle
+# ---------------------------------------------------------------------------
+
+main() {
+  mkdir -p "${STATE_DIR}"
+  mkdir -p "$(dirname "${LOG_FILE}")"
+
+  local was_alerted failures
+  was_alerted=$(state_get "alerted" "false")
+  failures=$(state_get "consecutive_failures" "0")
+
+  # An unreachable Transmission is a different problem with its own monitoring
+  # (the container health check restarts it). Reporting it as lost port
+  # forwarding would be wrong, and counting it toward the failure streak would
+  # eventually alert for the wrong reason. Leave the streak untouched.
+  local port
+  if ! port="$(peer_port)"; then
+    log "Transmission RPC unreachable — skipping this cycle"
+    exit 0
+  fi
+
+  local open
+  open="$(port_is_open)"
+
+  # Two independent symptoms of the same loss. A zero port means the peer port
+  # was never set or was zeroed; "no" means it is set but nothing outside can
+  # reach it. Either one stops new torrents from starting.
+  local bad=false
+  local reason=""
+  if [[ "${port}" == "0" ]]; then
+    bad=true
+    reason="Transmission's peer port is 0 — no port is set at all."
+  elif [[ "${open}" == "no" ]]; then
+    bad=true
+    reason="Peer port ${port} is set but is not reachable from outside."
+  fi
+
+  local now
+  now=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+  if [[ "${bad}" == "true" ]]; then
+    failures=$((failures + 1))
+    log "Port forwarding looks lost (${failures}/${CONSECUTIVE_FAILURE_THRESHOLD}): ${reason}"
+
+    # Alert on the transition into the bad state, not once per cycle. A 47-hour
+    # outage at a 15-minute cadence would otherwise be ~190 identical emails.
+    if [[ ${failures} -ge ${CONSECUTIVE_FAILURE_THRESHOLD} ]] && [[ "${was_alerted}" != "true" ]]; then
+      log "ALERT: port forwarding lost — notifying ${MONITORING_EMAIL}"
+      if send_email \
+        "[${SERVER_NAME}] Transmission port forwarding lost" \
+        "PIA port forwarding appears to be lost on ${SERVER_NAME}.
+
+${reason}
+
+  Peer port:     ${port}
+  Port is open:  ${open}
+
+Downloads already in progress will continue, more slowly. Newly added
+torrents will not start: with no reachable peer port, tracker announces fail
+and magnet links cannot fetch metadata over DHT. That is why this fails
+quietly and needs an alert at all.
+
+To investigate:
+  ssh operator@${HOSTNAME_LOWER} podman logs --tail 100 transmission-vpn | grep pia-port
+
+The port forwarding manager logs its own outcome there. 'REFUSING to apply
+invalid port forwarding result' means PIA declined to issue a port; the
+existing port was deliberately kept rather than zeroed.
+
+If the region stopped serving port forwarding, survey the alternatives:
+  ssh operator@${HOSTNAME_LOWER} ~/containers/transmission/scripts/pia-pf-probe.sh --all"; then
+        was_alerted=true
+      else
+        log "ERROR: failed to send alert email"
+      fi
+    fi
+  else
+    # Recovered: tell whoever got the alert, then reset so the next loss alerts
+    # again.
+    if [[ "${was_alerted}" == "true" ]]; then
+      log "RESOLVED: port forwarding restored on port ${port}"
+      send_email \
+        "[${SERVER_NAME}] Transmission port forwarding restored" \
+        "Port forwarding is working again on ${SERVER_NAME}.
+
+  Peer port:     ${port}
+  Port is open:  ${open}
+
+No action required." || true
+    fi
+    was_alerted=false
+    failures=0
+    maybe_heartbeat "peer port ${port}, reachable: ${open}"
+  fi
+
+  local heartbeat
+  heartbeat="$(state_get "last_heartbeat" "${now}")"
+
+  local new_state
+  new_state=$(jq -n \
+    --arg lp "${now}" \
+    --arg lh "${heartbeat}" \
+    --arg pt "${port}" \
+    --arg po "${open}" \
+    --argjson cf "${failures}" \
+    --argjson al "${was_alerted}" \
+    '{
+      last_poll: $lp,
+      last_heartbeat: $lh,
+      peer_port: $pt,
+      port_is_open: $po,
+      consecutive_failures: $cf,
+      alerted: $al
+    }')
+
+  write_state "${new_state}"
+}
+
+# Entry point — skipped when sourced for tests (TEST_RUNNER=true)
+if [[ "${TEST_RUNNER:-false}" != "true" ]]; then
+  main "$@"
+fi

--- a/app-setup/templates/transmission-post-start.sh
+++ b/app-setup/templates/transmission-post-start.sh
@@ -146,6 +146,13 @@ pf_gateway() {
   ip route 2>/dev/null | grep tun | grep -v src | head -1 | awk '{print $3}'
 }
 
+# Same value, but safe to interpolate into a log line before the tunnel is up.
+pf_gateway_or_unknown() {
+  local gateway
+  gateway="$(pf_gateway)"
+  printf '%s' "${gateway:-not yet established}"
+}
+
 # Populates pf_token. Returns non-zero if PIA would not issue one.
 get_auth_token() {
   local response
@@ -208,6 +215,11 @@ get_signature() {
   pf_port="$(jq -r '.port // empty' <<<"${decoded}" 2>/dev/null)"
   local expiry_raw
   expiry_raw="$(jq -r '.expires_at // empty' <<<"${decoded}" 2>/dev/null)"
+  # GNU date only: --date is rejected by BSD/macOS date. This script always runs
+  # inside the Linux container, so that is correct here — but anyone sourcing it
+  # on macOS (a future BATS test exercising get_signature, say) gets expiry 0
+  # from the fallback, which forces a full token renewal every cycle instead of
+  # a cheap re-bind. Degraded but safe, and silent, so it is worth knowing.
   pf_token_expiry="$(date --date="${expiry_raw}" +%s 2>/dev/null || echo 0)"
 }
 
@@ -257,7 +269,18 @@ pf_signature=""
 pf_port=""
 pf_token_expiry=0
 
-log "Starting PIA port forwarding manager (region: ${OPENVPN_CONFIG:-unknown})"
+# The image invokes this hook from /etc/transmission/start.sh without exporting
+# the container environment, so OPENVPN_CONFIG (and every other `podman run -e`
+# variable) is absent here — a previous version of this line logged
+# "region: unknown" on every start and cost real debugging time during the
+# 2026-08-23 incident by looking like a misconfiguration (issue #182).
+#
+# The tunnel gateway is derived from the routing table rather than the
+# environment, so it is always available, and it is the more useful value: it
+# is the endpoint the port-forwarding API is queried against, and it reflects
+# what actually connected rather than what was requested.
+startup_gateway="$(pf_gateway_or_unknown)"
+log "Starting PIA port forwarding manager (tunnel gateway: ${startup_gateway})"
 
 # Transmission has to be accepting RPC before a port can be set.
 until transmission-remote "${TRANSMISSION_HOST}" "${TR_AUTH[@]}" -si >/dev/null 2>&1; do

--- a/docs/apps/pia-vpn-README.md
+++ b/docs/apps/pia-vpn-README.md
@@ -162,7 +162,7 @@ load-bearing: Podman already provides the TUN device, and without it the image
 tries to create its own, fails with `cannot remove '/dev/net/tun': Device or
 resource busy`, and exits before attempting a tunnel.
 
-Changing regions means setting `PIA_VPN_REGION` (default `panama`) and
+Changing regions means setting `PIA_VPN_REGION` (default `ca_vancouver`) and
 recreating the container.
 
 ### Region names: image config vs PIA API

--- a/docs/apps/pia-vpn-README.md
+++ b/docs/apps/pia-vpn-README.md
@@ -137,16 +137,26 @@ The only reliable test is to establish a tunnel and ask. That is what
 [`app-setup/templates/pia-pf-probe.sh`](../../app-setup/templates/pia-pf-probe.sh)
 does:
 
+`podman-transmission-setup.sh` deploys it to
+`~operator/containers/transmission/scripts/pia-pf-probe.sh`, next to the port
+guard and the post-start hook. Run it from there on the server — that copy
+reads the PIA credentials from the sibling `.env` the container uses, and the
+operator account has no repo checkout:
+
 ```bash
 # Probe the default shortlist
-sudo -u operator ./app-setup/templates/pia-pf-probe.sh
+ssh operator@tilsit ~/containers/transmission/scripts/pia-pf-probe.sh
 
 # Probe specific regions
-sudo -u operator ./app-setup/templates/pia-pf-probe.sh ca_toronto netherlands
+ssh operator@tilsit ~/containers/transmission/scripts/pia-pf-probe.sh ca_vancouver netherlands
 
 # Sweep everything advertising PF (slow — roughly 90s per region)
-sudo -u operator ./app-setup/templates/pia-pf-probe.sh --all --out results.csv
+ssh operator@tilsit ~/containers/transmission/scripts/pia-pf-probe.sh --all --out results.csv
 ```
+
+From a repo checkout on the server, `sudo -u operator
+./app-setup/templates/pia-pf-probe.sh` works too, provided `PIA_ENV_FILE`
+points at the operator's `.env`.
 
 The probe runs in its own throwaway container and does not disturb the live
 `transmission-vpn` container or any download in progress.

--- a/docs/apps/transmission-filebot-README.md
+++ b/docs/apps/transmission-filebot-README.md
@@ -340,6 +340,54 @@ VM and recreates the container to obtain fresh VirtioFS handles.
 > enforces NFS access restrictions at the kernel level for any process
 > without FDA, including system XPC services.
 
+### Every podman call is bounded by a timeout
+
+The supervision loop is single-threaded: it calls `ensure_machine`,
+`ensure_container`, and `check_data_access` synchronously. A podman command
+that never returns therefore freezes the whole loop — no health checks, no
+recovery, no log output.
+
+That is not hypothetical. On 2026-08-16 the `/data/` health check correctly
+detected a VirtioFS failure and triggered its documented recovery. The
+recovery's `podman run -d` was issued through a Homebrew-upgraded 6.1.0 CLI
+while a leftover 6.0.2 `gvproxy`, orphaned by the upgrade seven days earlier,
+still held the machine's socket paths. That `podman run` hung and was still
+running 27 hours later. Nothing was listening on port 9091 the entire time.
+
+Two changes close that hole:
+
+- **`podman_t` wraps every podman invocation in `timeout(1)`.** Command
+  timeouts default to 60s, machine operations to 180s; override with
+  `PODMAN_CMD_TIMEOUT` / `PODMAN_MACHINE_TIMEOUT`. A timeout is logged as
+  `TIMEOUT: 'podman run -d' exceeded 180s and was killed` — deliberately
+  distinct from an ordinary failure, because not being able to tell a hang
+  from a failure is what made the outage take 27 hours to spot. The caller
+  treats a timeout like any other failure and retries next cycle.
+
+  `timeout(1)` is required, not optional. It comes from `coreutils`, which
+  `config/formulae.txt` installs. If it is missing the loop exits at startup
+  with instructions rather than running unsupervised. A `perl -e 'alarm'`
+  fallback was tried and rejected: SIGALRM kills perl but leaves the command's
+  children running, so they hold the command-substitution pipe open and
+  `state=$(podman_t ... machine inspect)` blocks forever regardless.
+
+- **`reap_machine_helpers` verifies the helper processes actually exited.**
+  `podman machine stop` returning 0 does not mean `gvproxy` and `vfkit` are
+  gone — the 6.0.2 `gvproxy` in the August incident survived for seven days.
+  Before any machine start, and after the recovery path's machine stop, any
+  surviving helper whose argv names `transmission-vm` gets SIGTERM, then
+  SIGKILL if it ignores that. The match is scoped to the machine name so other
+  podman machines on the host are untouched.
+
+**Podman version drift is the underlying trigger.** A `brew upgrade` replaces
+the CLI without restarting the running VM or its helpers. The timeout and reap
+changes make the resulting mismatch recoverable rather than fatal; they do not
+prevent the drift itself. After upgrading podman, cycle the machine:
+
+```bash
+launchctl kickstart -k "gui/$(id -u)/com.tilsit.podman-transmission-vm"
+```
+
 ## Common Gotchas
 
 1. **PATH issues**: Transmission runs scripts with minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). Script adds `/usr/local/bin:/opt/homebrew/bin` explicitly for Homebrew tools.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -93,6 +93,27 @@ else
 fi
 echo
 
+# Run top-level component tests
+# These live at tests/*.bats rather than under tests/transmission-filebot/, so
+# neither glob above reaches them. Discovered with nullglob so an empty match
+# is reported as "none found" instead of bats being handed a literal '*'.
+echo -e "${YELLOW}Running Component Tests...${NC}"
+echo -e "${BLUE}────────────────────────────────────────${NC}"
+shopt -s nullglob
+COMPONENT_TESTS=(tests/*.bats)
+shopt -u nullglob
+if [[ ${#COMPONENT_TESTS[@]} -eq 0 ]]; then
+  echo "No component tests found at tests/*.bats"
+  COMPONENT_RESULT=0
+elif bats "${COMPONENT_TESTS[@]}"; then
+  echo -e "${GREEN}✓ Component tests passed${NC}"
+  COMPONENT_RESULT=0
+else
+  echo -e "${RED}✗ Component tests failed${NC}"
+  COMPONENT_RESULT=1
+fi
+echo
+
 # Summary
 echo -e "${BLUE}========================================${NC}"
 echo -e "${BLUE}Test Summary${NC}"
@@ -110,10 +131,16 @@ else
   echo -e "Integration Tests: ${RED}✗ FAILED${NC}"
 fi
 
+if [[ ${COMPONENT_RESULT} -eq 0 ]]; then
+  echo -e "Component Tests:   ${GREEN}✓ PASSED${NC}"
+else
+  echo -e "Component Tests:   ${RED}✗ FAILED${NC}"
+fi
+
 echo -e "${BLUE}========================================${NC}"
 
 # Exit with failure if any tests failed
-if [[ ${UNIT_RESULT} -ne 0 ]] || [[ ${INTEGRATION_RESULT} -ne 0 ]]; then
+if [[ ${UNIT_RESULT} -ne 0 ]] || [[ ${INTEGRATION_RESULT} -ne 0 ]] || [[ ${COMPONENT_RESULT} -ne 0 ]]; then
   echo -e "${RED}Some tests failed${NC}"
   exit 1
 else

--- a/tests/pia-pf-probe.bats
+++ b/tests/pia-pf-probe.bats
@@ -1,0 +1,287 @@
+#!/usr/bin/env bats
+#
+# Tests for pia-pf-probe.sh — the one-shot region survey that reports which PIA
+# regions actually serve port forwarding.
+#
+# The script exposes the same TEST_RUNNER hook cloudflare-ddns.sh uses: setting
+# TEST_RUNNER=true before sourcing skips the `main "$@"` entry point, so the
+# functions can be exercised individually with `podman` and `curl` stubbed out.
+#
+# Two failure modes drive this suite:
+#
+#   1. An empty region list must abort, not probe an empty region name. A
+#      here-string always appends a newline, so `mapfile -t regions <<<""`
+#      yields regions=("") — one empty element — which slips past a
+#      `${#regions[@]} -gt 0` guard and emits a nonsense CSV row (issue #171).
+#
+#   2. `tunnel_timeout` is the script's catch-all for "no tunnel appeared",
+#      which an unknown region name produces just as readily as a dead
+#      endpoint. That ambiguity cost a full survey run (issue #174), so the row
+#      format it emits is pinned here.
+#
+# Run with: bats tests/pia-pf-probe.bats
+
+BATS_TEST_FILENAME="${BATS_TEST_FILENAME:-}"
+REPO_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+PROBE="${REPO_DIR}/app-setup/templates/pia-pf-probe.sh"
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  export TEST_TMPDIR
+  MOCK_BIN_DIR="${TEST_TMPDIR}/bin"
+  mkdir -p "${MOCK_BIN_DIR}"
+
+  export CALL_LOG="${TEST_TMPDIR}/calls.log"
+  : >"${CALL_LOG}"
+
+  # Stub podman so no container is ever created. Behaviour is switched by
+  # files rather than env vars because each invocation is a fresh process.
+  export PODMAN_RUN_RC_FILE="${TEST_TMPDIR}/podman_run_rc"
+  echo 0 >"${PODMAN_RUN_RC_FILE}"
+
+  cat >"${MOCK_BIN_DIR}/podman" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CALL_LOG}"
+case "$1" in
+  run)
+    exit "$(cat "${PODMAN_RUN_RC_FILE}")"
+    ;;
+  exec)
+    # Never report a tunnel gateway, so probe_region takes the timeout path.
+    exit 0
+    ;;
+  rm)
+    exit 0
+    ;;
+esac
+exit 0
+STUB
+  chmod +x "${MOCK_BIN_DIR}/podman"
+
+  # curl and jq only have to exist for require_deps; the tests that care about
+  # region discovery stub list_pf_regions directly rather than going near the
+  # network, so neither stub needs to produce meaningful output.
+  local stub
+  for stub in curl jq; do
+    printf '#!/usr/bin/env bash\nexit 0\n' >"${MOCK_BIN_DIR}/${stub}"
+    chmod +x "${MOCK_BIN_DIR}/${stub}"
+  done
+
+  export PATH="${MOCK_BIN_DIR}:${PATH}"
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+}
+
+# Source the probe with its entry point disabled, so only definitions load.
+load_probe() {
+  export TEST_RUNNER=true
+  # shellcheck source=/dev/null
+  source "${PROBE}"
+}
+
+# ---------------------------------------------------------------------------
+# Empty region list must abort (#171)
+# ---------------------------------------------------------------------------
+
+@test "an empty region list aborts instead of probing an empty region name" {
+  # Reproduces the exact shape of the bug: --all with a list_pf_regions that
+  # returns nothing, which is what a curl failure or a server list with no
+  # port_forward=true entries produces.
+  local script="${TEST_TMPDIR}/probe.sh"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'TEST_RUNNER=true'
+    printf '%s\n' "source \"${PROBE}\""
+    printf '%s\n' 'list_pf_regions() { printf ""; }'
+    printf '%s\n' 'load_credentials() { PIA_USERNAME=u; PIA_PASSWORD=p; }'
+    printf '%s\n' 'probe_region() { printf "PROBED:[%s]\n" "$1" >&2; printf "x,no,stub,,,\n"; }'
+    printf '%s\n' 'cleanup_probe_container() { :; }'
+    printf '%s\n' "main --all --out \"${TEST_TMPDIR}/out.csv\""
+  } >"${script}"
+
+  run bash "${script}"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No regions advertising port_forward=true"* ]]
+  # The decisive assertion: probe_region must never have been reached.
+  [[ "$output" != *"PROBED:"* ]]
+}
+
+@test "mapfile on an empty here-string would otherwise yield one empty element" {
+  # Pins the bash behaviour the guard exists to defeat. If this ever stops
+  # being true the explicit -z check becomes dead code rather than load-bearing.
+  local count first
+  count=$(
+    mapfile -t a <<<""
+    echo "${#a[@]}"
+  )
+  first=$(
+    mapfile -t a <<<""
+    printf '[%s]' "${a[0]}"
+  )
+  [ "${count}" -eq 1 ]
+  [ "${first}" = "[]" ]
+}
+
+@test "a populated region list is probed one region per line" {
+  local script="${TEST_TMPDIR}/probe.sh"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'TEST_RUNNER=true'
+    printf '%s\n' "source \"${PROBE}\""
+    printf '%s\n' 'list_pf_regions() { printf "ca_vancouver\nde_frankfurt\n"; }'
+    printf '%s\n' 'load_credentials() { PIA_USERNAME=u; PIA_PASSWORD=p; }'
+    # An OK row so main's "nothing confirmed" exit-1 path is not what is under
+    # test here; the region-to-row mapping is.
+    printf '%s\n' 'probe_region() { printf "%s,yes,OK,40001,10.0.0.1,confirmed\n" "$1"; }'
+    printf '%s\n' 'cleanup_probe_container() { :; }'
+    printf '%s\n' "main --all --out \"${TEST_TMPDIR}/out.csv\""
+  } >"${script}"
+
+  run bash "${script}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2 candidate regions"* ]]
+  [[ "$output" == *"2/2 region(s) with working port forwarding"* ]]
+
+  run grep -c . "${TEST_TMPDIR}/out.csv"
+  # Header plus one row per region.
+  [ "$output" -eq 3 ]
+
+  run grep -q '^ca_vancouver,' "${TEST_TMPDIR}/out.csv"
+  [ "$status" -eq 0 ]
+  run grep -q '^de_frankfurt,' "${TEST_TMPDIR}/out.csv"
+  [ "$status" -eq 0 ]
+  # No empty-region row.
+  run grep -q '^,' "${TEST_TMPDIR}/out.csv"
+  [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# CSV contract (#174)
+# ---------------------------------------------------------------------------
+
+@test "the CSV header names all six columns every row must fill" {
+  local script="${TEST_TMPDIR}/probe.sh"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'TEST_RUNNER=true'
+    printf '%s\n' "source \"${PROBE}\""
+    printf '%s\n' 'load_credentials() { PIA_USERNAME=u; PIA_PASSWORD=p; }'
+    printf '%s\n' 'probe_region() { printf "%s,no,stub,,,note\n" "$1"; }'
+    printf '%s\n' 'cleanup_probe_container() { :; }'
+    printf '%s\n' "main --out \"${TEST_TMPDIR}/out.csv\" ca_vancouver"
+  } >"${script}"
+
+  # Nothing confirmed, so main exits 1 by design — the header is still written.
+  run bash "${script}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No region returned a usable forwarded port"* ]]
+
+  run head -1 "${TEST_TMPDIR}/out.csv"
+  [ "$output" = "region,tunnel_up,pf_status,port,gateway,notes" ]
+}
+
+@test "a container that never starts is reported as container_failed, not a tunnel problem" {
+  load_probe
+  echo 1 >"${PODMAN_RUN_RC_FILE}"
+  # probe_region interpolates the credentials into the podman run flags; main
+  # normally sets them via load_credentials.
+  PIA_USERNAME=u
+  PIA_PASSWORD=p
+
+  run probe_region "bogus_region"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "bogus_region,no,container_failed,,,could not start probe container" ]]
+}
+
+@test "a container that starts but never routes is reported as tunnel_timeout" {
+  # This is the ambiguous row from #174: an unknown region name and a dead
+  # endpoint are indistinguishable here. Pinning the format is what makes a
+  # future disambiguation a visible, test-breaking change rather than a silent
+  # one.
+  load_probe
+  echo 0 >"${PODMAN_RUN_RC_FILE}"
+  PIA_USERNAME=u
+  PIA_PASSWORD=p
+  # Collapse the wait so the test does not sit through the real 90s timeout.
+  # probe_region reads TUNNEL_TIMEOUT from the enclosing scope; assigning it on
+  # the call keeps that dependency explicit.
+  TUNNEL_TIMEOUT=0 run probe_region "ca_vancouver"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "ca_vancouver,no,tunnel_timeout,,,no tunnel after 0s" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Credential loading
+# ---------------------------------------------------------------------------
+
+@test "credentials are read from PIA_ENV_FILE rather than the command line" {
+  load_probe
+
+  local env_file="${TEST_TMPDIR}/pia.env"
+  printf 'PIA_USERNAME=p1234567\nPIA_PASSWORD=s3cr3t\n' >"${env_file}"
+
+  PIA_ENV_FILE="${env_file}" load_credentials
+  [ "${PIA_USERNAME}" = "p1234567" ]
+  [ "${PIA_PASSWORD}" = "s3cr3t" ]
+}
+
+@test "a password containing '=' survives credential parsing intact" {
+  # cut -d= -f2- keeps everything after the first '='; -f2 alone would truncate.
+  load_probe
+
+  local env_file="${TEST_TMPDIR}/pia.env"
+  printf 'PIA_USERNAME=p1234567\nPIA_PASSWORD=a=b=c\n' >"${env_file}"
+
+  PIA_ENV_FILE="${env_file}" load_credentials
+  [ "${PIA_PASSWORD}" = "a=b=c" ]
+}
+
+@test "a missing env file fails loudly instead of probing without credentials" {
+  load_probe
+
+  run load_credentials
+  # die() exits non-zero rather than returning, so run captures the exit.
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Cannot read PIA env file"* ]]
+}
+
+@test "an env file missing PIA_PASSWORD is rejected" {
+  load_probe
+
+  local env_file="${TEST_TMPDIR}/pia.env"
+  printf 'PIA_USERNAME=p1234567\n' >"${env_file}"
+
+  PIA_ENV_FILE="${env_file}" run load_credentials
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"PIA_PASSWORD missing"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+@test "an unknown option is rejected rather than treated as a region name" {
+  local script="${TEST_TMPDIR}/probe.sh"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'TEST_RUNNER=true'
+    printf '%s\n' "source \"${PROBE}\""
+    printf '%s\n' 'load_credentials() { PIA_USERNAME=u; PIA_PASSWORD=p; }'
+    printf '%s\n' 'probe_region() { printf "%s,no,stub,,,\n" "$1"; }'
+    printf '%s\n' 'cleanup_probe_container() { :; }'
+    printf '%s\n' 'main --nonsense'
+  } >"${script}"
+
+  run bash "${script}"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown option: --nonsense"* ]]
+}
+
+@test "the TEST_RUNNER hook keeps sourcing side-effect free" {
+  # If main ran on source, every test above would probe for real.
+  run grep -E '^if \[\[ "\$\{TEST_RUNNER:-false\}" != "true" \]\]; then' "${PROBE}"
+  [ "$status" -eq 0 ]
+}

--- a/tests/pia-port-watchdog.bats
+++ b/tests/pia-port-watchdog.bats
@@ -1,0 +1,364 @@
+#!/usr/bin/env bats
+#
+# Tests for pia-port-watchdog.sh — the alert for lost PIA port forwarding.
+#
+# The behaviour under test is what made the August outage invisible (issue
+# #181): downloads keep working without a forwarded port, so nothing that
+# watches download activity notices. Only newly added torrents break. Port
+# forwarding was dead for about 47 hours and nothing alerted.
+#
+# Two mistakes would make this watchdog worse than useless:
+#
+#   1. Alerting on the transient zero the peer port legitimately shows for a
+#      few seconds during a container restart. A watchdog that cries wolf gets
+#      filtered, and then the real outage is invisible again.
+#
+#   2. Alerting every cycle. At a 15-minute cadence a 47-hour outage is ~190
+#      identical emails, which has the same end result.
+#
+# The script uses the same TEST_RUNNER hook as cloudflare-ddns.sh and
+# pia-pf-probe.sh: TEST_RUNNER=true before sourcing skips `main "$@"`.
+#
+# Run with: bats tests/pia-port-watchdog.bats
+
+BATS_TEST_FILENAME="${BATS_TEST_FILENAME:-}"
+REPO_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+TEMPLATE="${REPO_DIR}/app-setup/templates/pia-port-watchdog.sh"
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  export TEST_TMPDIR
+  MOCK_BIN_DIR="${TEST_TMPDIR}/bin"
+  mkdir -p "${MOCK_BIN_DIR}"
+
+  # HOME drives every path the script writes to, so pointing it at the sandbox
+  # keeps state, logs and the msmtp config out of the real home directory.
+  export HOME="${TEST_TMPDIR}/home"
+  mkdir -p "${HOME}/.config/msmtp" "${HOME}/.local/state"
+  touch "${HOME}/.config/msmtp/config"
+
+  export MAIL_LOG="${TEST_TMPDIR}/mail.log"
+  : >"${MAIL_LOG}"
+
+  # RPC responses are read from files so a test can change what Transmission
+  # reports between invocations.
+  export RPC_PEER_PORT_FILE="${TEST_TMPDIR}/peer_port"
+  export RPC_PORT_OPEN_FILE="${TEST_TMPDIR}/port_open"
+  export RPC_REACHABLE_FILE="${TEST_TMPDIR}/reachable"
+  echo "51413" >"${RPC_PEER_PORT_FILE}"
+  echo "true" >"${RPC_PORT_OPEN_FILE}"
+  echo "true" >"${RPC_REACHABLE_FILE}"
+
+  write_curl_mock
+  write_msmtp_mock
+  render_template
+  export PATH="${MOCK_BIN_DIR}:${PATH}"
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+}
+
+# ---------------------------------------------------------------------------
+# Render the template the way podman-transmission-setup.sh does, so the tests
+# exercise what actually gets deployed rather than the placeholder version.
+# ---------------------------------------------------------------------------
+render_template() {
+  WATCHDOG="${TEST_TMPDIR}/pia-port-watchdog.sh"
+  sed \
+    -e "s|__SERVER_NAME__|TESTHOST|g" \
+    -e "s|__MONITORING_EMAIL__|ops@example.com|g" \
+    -e "s|__TRANSMISSION_HOST_PORT__|9091|g" \
+    "${TEMPLATE}" >"${WATCHDOG}"
+  chmod +x "${WATCHDOG}"
+  export WATCHDOG
+}
+
+# ---------------------------------------------------------------------------
+# curl mock. Serves the CSRF handshake, then session-get / port-test from the
+# state files. `-D -` (header dump) marks the session-id request.
+# ---------------------------------------------------------------------------
+write_curl_mock() {
+  cat >"${MOCK_BIN_DIR}/curl" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "$(cat "${RPC_REACHABLE_FILE}")" != "true" ]]; then
+  exit 7
+fi
+
+for arg in "$@"; do
+  if [[ "${arg}" == "-D" ]]; then
+    printf 'HTTP/1.1 409 Conflict\r\nX-Transmission-Session-Id: testtoken\r\n\r\n'
+    exit 0
+  fi
+done
+
+body=""
+for arg in "$@"; do
+  case "${arg}" in
+    *'"method":"session-get"'*)
+      body="{\"arguments\":{\"peer-port\":$(cat "${RPC_PEER_PORT_FILE}")},\"result\":\"success\"}"
+      ;;
+    *'"method":"port-test"'*)
+      body="{\"arguments\":{\"port-is-open\":$(cat "${RPC_PORT_OPEN_FILE}")},\"result\":\"success\"}"
+      ;;
+  esac
+done
+
+printf '%s' "${body}"
+MOCK
+  chmod +x "${MOCK_BIN_DIR}/curl"
+}
+
+write_msmtp_mock() {
+  cat >"${MOCK_BIN_DIR}/msmtp" <<'MOCK'
+#!/usr/bin/env bash
+{ echo "=== MAIL ==="; cat; } >>"${MAIL_LOG}"
+MOCK
+  chmod +x "${MOCK_BIN_DIR}/msmtp"
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+set_rpc() {
+  echo "$1" >"${RPC_PEER_PORT_FILE}"
+  echo "$2" >"${RPC_PORT_OPEN_FILE}"
+}
+
+run_cycle() {
+  bash "${WATCHDOG}"
+}
+
+mail_count() {
+  grep -c '^=== MAIL ===' "${MAIL_LOG}" || true
+}
+
+state_field() {
+  jq -r "$1" "${HOME}/.config/pia-port-watchdog/state.json"
+}
+
+watchdog_log() {
+  cat "${HOME}/.local/state/testhost-pia-port-watchdog.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Healthy state
+# ---------------------------------------------------------------------------
+
+@test "a forwarded, reachable port produces no alert" {
+  set_rpc "51413" "true"
+
+  run run_cycle
+  [ "$status" -eq 0 ]
+  [ "$(mail_count)" -eq 0 ]
+  [ "$(state_field '.consecutive_failures')" -eq 0 ]
+  [ "$(state_field '.alerted')" = "false" ]
+}
+
+# ---------------------------------------------------------------------------
+# Transient badness must not alert (#181: "don't alert on transient state")
+# ---------------------------------------------------------------------------
+
+@test "a single bad poll does not alert" {
+  # The peer port reads 0 for a few seconds during a container restart. Paging
+  # on that trains everyone to ignore the alert.
+  set_rpc "0" "false"
+
+  run run_cycle
+  [ "$status" -eq 0 ]
+  [ "$(mail_count)" -eq 0 ]
+  [ "$(state_field '.consecutive_failures')" -eq 1 ]
+}
+
+@test "two bad polls still do not alert" {
+  set_rpc "0" "false"
+
+  run_cycle
+  run_cycle
+
+  [ "$(mail_count)" -eq 0 ]
+  [ "$(state_field '.consecutive_failures')" -eq 2 ]
+}
+
+@test "a bad poll followed by a good one resets the streak" {
+  set_rpc "0" "false"
+  run_cycle
+  run_cycle
+  [ "$(state_field '.consecutive_failures')" -eq 2 ]
+
+  set_rpc "51413" "true"
+  run_cycle
+
+  [ "$(state_field '.consecutive_failures')" -eq 0 ]
+  [ "$(mail_count)" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Sustained loss must alert, exactly once
+# ---------------------------------------------------------------------------
+
+@test "three consecutive bad polls alert" {
+  set_rpc "0" "false"
+
+  run_cycle
+  run_cycle
+  run_cycle
+
+  [ "$(mail_count)" -eq 1 ]
+  [ "$(state_field '.alerted')" = "true" ]
+  grep -q "Transmission port forwarding lost" "${MAIL_LOG}"
+}
+
+@test "a continuing outage does not send a second alert" {
+  # 47 hours at a 15-minute cadence is ~190 emails if this is wrong, which is
+  # just a different way of not being noticed.
+  set_rpc "0" "false"
+
+  # Eight cycles of a continuing outage; only the first crossing of the
+  # threshold may send mail.
+  local remaining=8
+  while [[ ${remaining} -gt 0 ]]; do
+    run_cycle
+    remaining=$((remaining - 1))
+  done
+
+  [ "$(mail_count)" -eq 1 ]
+}
+
+@test "recovery sends exactly one all-clear and re-arms" {
+  set_rpc "0" "false"
+  run_cycle
+  run_cycle
+  run_cycle
+  [ "$(mail_count)" -eq 1 ]
+
+  set_rpc "51413" "true"
+  run_cycle
+  [ "$(mail_count)" -eq 2 ]
+  grep -q "port forwarding restored" "${MAIL_LOG}"
+  [ "$(state_field '.alerted')" = "false" ]
+
+  # Another cycle while healthy must stay quiet.
+  run_cycle
+  [ "$(mail_count)" -eq 2 ]
+
+  # A second loss has to alert again — the state was re-armed, not latched.
+  set_rpc "0" "false"
+  run_cycle
+  run_cycle
+  run_cycle
+  [ "$(mail_count)" -eq 3 ]
+}
+
+# ---------------------------------------------------------------------------
+# The subtler failure: a real port that nobody outside can reach
+# ---------------------------------------------------------------------------
+
+@test "a non-zero but unreachable port is treated as lost forwarding" {
+  # This is the state the port guard (#180) deliberately leaves behind on a PF
+  # failure: the existing port is kept rather than zeroed, so port != 0 while
+  # forwarding is gone. Checking only for zero would miss it entirely.
+  set_rpc "51413" "false"
+
+  run_cycle
+  run_cycle
+  run_cycle
+
+  [ "$(mail_count)" -eq 1 ]
+  grep -q "not reachable from outside" "${MAIL_LOG}"
+}
+
+@test "an unknown reachability result is not treated as a failure" {
+  # port-test can fail to answer for reasons unrelated to forwarding. Guessing
+  # "no" would alert on a tracker hiccup.
+  set_rpc "51413" "null"
+
+  run_cycle
+  run_cycle
+  run_cycle
+
+  [ "$(mail_count)" -eq 0 ]
+  [ "$(state_field '.consecutive_failures')" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Transmission being down is a different problem
+# ---------------------------------------------------------------------------
+
+@test "an unreachable Transmission is skipped, not reported as lost forwarding" {
+  echo "false" >"${RPC_REACHABLE_FILE}"
+
+  run run_cycle
+  [ "$status" -eq 0 ]
+  [ "$(mail_count)" -eq 0 ]
+  [[ "$(watchdog_log)" == *"RPC unreachable"* ]]
+}
+
+@test "an unreachable Transmission does not advance the failure streak" {
+  # Otherwise a container that is down for an hour eventually alerts about port
+  # forwarding, which is the wrong diagnosis and sends the reader somewhere
+  # unhelpful. The container health check already covers this case.
+  set_rpc "0" "false"
+  run_cycle
+  run_cycle
+  [ "$(state_field '.consecutive_failures')" -eq 2 ]
+
+  echo "false" >"${RPC_REACHABLE_FILE}"
+  run_cycle
+  run_cycle
+  run_cycle
+
+  [ "$(mail_count)" -eq 0 ]
+  [ "$(state_field '.consecutive_failures')" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Alert content
+# ---------------------------------------------------------------------------
+
+@test "the alert explains why the failure is invisible and where to look" {
+  set_rpc "0" "false"
+  run_cycle
+  run_cycle
+  run_cycle
+
+  # Without this context the reader sees "port forwarding lost" and reasonably
+  # concludes downloads have stopped, which is not what happens.
+  grep -q "Newly added" "${MAIL_LOG}"
+  grep -q "podman logs" "${MAIL_LOG}"
+  grep -q "pia-pf-probe.sh" "${MAIL_LOG}"
+}
+
+# ---------------------------------------------------------------------------
+# Deployment wiring
+# ---------------------------------------------------------------------------
+
+@test "every placeholder is substituted at deploy time" {
+  run grep -c '__[A-Z_]*__' "${WATCHDOG}"
+  [ "$output" -eq 0 ]
+}
+
+@test "the setup script substitutes exactly the placeholders the template declares" {
+  local placeholder
+  while IFS= read -r placeholder; do
+    grep -q "s|${placeholder}|" "${REPO_DIR}/app-setup/podman-transmission-setup.sh" \
+      || {
+        echo "setup script never substitutes ${placeholder}" >&2
+        return 1
+      }
+  done < <(grep -oE '__[A-Z_]+__' "${TEMPLATE}" | sort -u)
+}
+
+@test "the watchdog is only deployed when it can actually send mail" {
+  # An agent that runs every 15 minutes and can only log "cannot send email" is
+  # worse than no agent: it looks like monitoring without being any.
+  run grep -A 12 'PORT_WATCHDOG_DEPLOY=true' "${REPO_DIR}/app-setup/podman-transmission-setup.sh"
+  [[ "$output" == *"MONITORING_EMAIL"* ]]
+  [[ "$output" == *"msmtp"* ]]
+}
+
+@test "the LaunchAgent polls often enough to catch a loss within the hour" {
+  run grep -A 20 'pia-port-watchdog.plist' "${REPO_DIR}/app-setup/podman-transmission-setup.sh"
+  [[ "$output" == *"<integer>900</integer>"* ]]
+}

--- a/tests/pia-port-watchdog.bats
+++ b/tests/pia-port-watchdog.bats
@@ -362,3 +362,33 @@ watchdog_log() {
   run grep -A 20 'pia-port-watchdog.plist' "${REPO_DIR}/app-setup/podman-transmission-setup.sh"
   [[ "$output" == *"<integer>900</integer>"* ]]
 }
+
+@test "the remediation path in the alert is a path that actually gets deployed" {
+  # The alert tells an operator to run pia-pf-probe.sh at a specific path. If
+  # nothing deploys it there the advice is worse than none: it sends someone
+  # mid-incident to a file that does not exist. The repo checkout is not an
+  # answer — the operator account does not have one.
+  # Build the tilde from its character code rather than writing one: a literal
+  # ~ inside quotes trips SC2088, which is a false positive here (this is a
+  # grep pattern, not a path being expanded).
+  local tilde
+  tilde="$(printf '\176')"
+
+  local referenced
+  referenced="$(grep -oE "${tilde}/[a-zA-Z0-9_./-]*pia-pf-probe\.sh" "${TEMPLATE}" | head -1)"
+  [ -n "${referenced}" ]
+
+  # Reduce the referenced path to the part below the container directory, which
+  # is what the setup script's destination is expressed relative to.
+  local suffix="${referenced#"${tilde}"/containers/transmission/}"
+  [ "${suffix}" = "scripts/pia-pf-probe.sh" ]
+
+  run grep -q 'PF_PROBE_DEST="\${CONTAINER_DIR}/scripts/pia-pf-probe.sh"' \
+    "${REPO_DIR}/app-setup/podman-transmission-setup.sh"
+  [ "$status" -eq 0 ]
+
+  # And it must actually be copied, not just have a variable defined for it.
+  run grep -q 'sudo cp "\${PF_PROBE_TEMPLATE}" "\${PF_PROBE_DEST}"' \
+    "${REPO_DIR}/app-setup/podman-transmission-setup.sh"
+  [ "$status" -eq 0 ]
+}

--- a/tests/podman-machine-start.bats
+++ b/tests/podman-machine-start.bats
@@ -50,6 +50,25 @@ setup() {
   extract_and_render_wrapper
   write_podman_mock
   write_mount_mock
+  link_timeout
+}
+
+# ---------------------------------------------------------------------------
+# The wrapper resets PATH to "${HOMEBREW_PREFIX}/bin:...:/usr/bin:/bin", and
+# the tests point HOMEBREW_PREFIX at the sandbox so the podman mock is found
+# first. timeout(1) is coreutils, which lives in the real Homebrew prefix and
+# is therefore off that PATH — so link it in. The wrapper now requires it and
+# exits at startup without it (#168), which would fail every test here for a
+# reason that has nothing to do with what is under test.
+# ---------------------------------------------------------------------------
+link_timeout() {
+  local real_timeout
+  real_timeout="$(command -v timeout || true)"
+  if [[ -z "${real_timeout}" ]]; then
+    echo "timeout(1) not found — install coreutils (brew install coreutils)" >&2
+    return 1
+  fi
+  ln -sf "${real_timeout}" "${MOCK_BIN_DIR}/timeout"
 }
 
 # ---------------------------------------------------------------------------
@@ -292,4 +311,169 @@ run_wrapper_briefly() {
   local inspect_calls
   inspect_calls=$(call_count "machine inspect transmission-vm")
   [ "${inspect_calls}" -ge 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Timeout hardening (#168)
+#
+# On 2026-08-16 a `podman run -d` issued through a freshly upgraded 6.1.0 CLI,
+# against a machine whose 6.0.2 gvproxy still held the socket paths, hung
+# indefinitely. The supervision loop calls ensure_container synchronously, so
+# the hang froze the entire loop for 27 hours: no log lines, no container,
+# nothing listening on the web UI port, and none of the automatic recovery the
+# loop exists to provide.
+#
+# The regression these tests protect is not "podman failed" — the loop already
+# handled that — it is "podman never returned".
+# ---------------------------------------------------------------------------
+
+# Replace the podman mock with one that hangs on a chosen subcommand, so the
+# no-longer-unbounded wait can actually be exercised.
+write_hanging_podman_mock() {
+  local hang_on="$1"
+  cat >"${MOCK_BIN_DIR}/podman" <<MOCK_EOF
+#!/usr/bin/env bash
+echo "\$*" >>"\${CALLS_FILE}"
+if [[ "\$1" == "${hang_on}" ]]; then
+  # Reproduce the 2026-08-16 hang: never return, never print.
+  sleep 3600
+fi
+case "\$*" in
+  "machine inspect"*) cat "\${MACHINE_STATE_FILE}"; exit 0 ;;
+  "machine start"*)   echo running >"\${MACHINE_STATE_FILE}"; exit 0 ;;
+  "machine stop"*)    echo stopped >"\${MACHINE_STATE_FILE}"; exit 0 ;;
+esac
+case "\$1" in
+  info)      exit 0 ;;
+  container) [[ "\$(cat "\${CONTAINER_EXISTS_FILE}")" == "true" ]] && exit 0 || exit 1 ;;
+  inspect)   cat "\${CONTAINER_RUNNING_FILE}"; exit 0 ;;
+  *)         exit 0 ;;
+esac
+MOCK_EOF
+  chmod +x "${MOCK_BIN_DIR}/podman"
+}
+
+@test "every podman call in the supervision loop is bounded by a timeout" {
+  # The whole class of bug: any unbounded podman invocation can freeze the loop.
+  # Assert none survive rather than enumerating the ones that were fixed, so a
+  # newly added bare call fails this test instead of shipping.
+  # Only command positions count. Comments legitimately name `podman machine
+  # stop` in the header's maintenance notes, and log strings mention podman in
+  # prose; neither is an invocation. A real call starts a line, follows `$(`,
+  # or follows `!`/`&&`/`||`/`;`.
+  run bash -c "grep -vE '^[[:space:]]*#' \"${WRAPPER_SCRIPT}\" | grep -nE '(^[[:space:]]*|\\\$\\(|[!;][[:space:]]*|&&[[:space:]]*|\\|\\|[[:space:]]*)podman[[:space:]]+[a-z]'"
+
+  local line
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    # podman_t's own body is the one place a bare `podman` is correct — it is
+    # what _timeout wraps.
+    [[ "${line}" == *'_timeout "${limit}" podman'* ]] && continue
+    echo "unbounded podman call: ${line}" >&2
+    return 1
+  done <<<"${output}"
+}
+
+@test "a hung podman run is killed rather than freezing the loop forever" {
+  set_mock_state "running" "false" "false"
+  write_hanging_podman_mock "run"
+
+  # 3s budget against a mock that sleeps for an hour. Before the fix this
+  # blocked inside ensure_container and the loop never iterated again.
+  PODMAN_MACHINE_TIMEOUT=2 PODMAN_CMD_TIMEOUT=2 SUPERVISE_INTERVAL=1 \
+    run timeout 12 "${WRAPPER_SCRIPT}"
+
+  # Killed by the outer timeout means the wrapper was still looping, not stuck.
+  [ "${status}" -eq 124 ]
+
+  # The decisive evidence: the loop kept going past the hung call.
+  local run_calls
+  run_calls=$(grep -c '^run -d' "${CALLS_FILE}" || true)
+  [ "${run_calls}" -ge 2 ]
+}
+
+@test "a timed-out podman call is logged distinctly from an ordinary failure" {
+  set_mock_state "running" "false" "false"
+  write_hanging_podman_mock "run"
+
+  PODMAN_MACHINE_TIMEOUT=2 PODMAN_CMD_TIMEOUT=2 SUPERVISE_INTERVAL=1 \
+    run timeout 8 "${WRAPPER_SCRIPT}"
+
+  # An operator reading the log has to be able to tell a hang from a failure —
+  # that distinction is what took 27 hours to spot the first time.
+  [[ "${output}" == *"TIMEOUT:"* ]]
+  [[ "${output}" == *"exceeded"* ]]
+  # Name the subcommand, not the forty-flag argv that buries it.
+  [[ "${output}" == *"TIMEOUT: 'podman run -d' exceeded"* ]]
+}
+
+@test "a hung machine inspect does not prevent later loop iterations" {
+  set_mock_state "running" "true" "true"
+  write_hanging_podman_mock "machine"
+
+  # Every `machine` subcommand hangs here, so each iteration burns the full
+  # timeout on inspect and again on start. Budget accordingly: 1s timeouts and
+  # a 15s run leave room for several iterations. Before the fix the first
+  # inspect never returned and there was no second iteration at all.
+  PODMAN_MACHINE_TIMEOUT=1 PODMAN_CMD_TIMEOUT=1 SUPERVISE_INTERVAL=1 \
+    run timeout 15 "${WRAPPER_SCRIPT}"
+
+  [ "${status}" -eq 124 ]
+  local inspect_calls
+  inspect_calls=$(call_count "machine inspect transmission-vm")
+  [ "${inspect_calls}" -ge 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Stale helper reaping (#168)
+# ---------------------------------------------------------------------------
+
+@test "the machine stop path verifies helper processes exited, not just the exit code" {
+  # `podman machine stop` returned 0 in the August incident while a 6.0.2
+  # gvproxy kept running for seven more days, still holding the socket paths
+  # the upgraded CLI then tried to reuse.
+  run grep -c 'reap_machine_helpers' "${WRAPPER_SCRIPT}"
+  # Defined once, called from the recovery path and before a machine start.
+  [ "${output}" -ge 3 ]
+}
+
+@test "reap_machine_helpers escalates to SIGKILL for a helper that ignores SIGTERM" {
+  run grep -A 30 '^reap_machine_helpers()' "${WRAPPER_SCRIPT}"
+  [[ "${output}" == *"kill -0"* ]]
+  [[ "${output}" == *"kill -9"* ]]
+}
+
+@test "reap_machine_helpers only targets this machine's helpers" {
+  # An unqualified `pkill gvproxy` would take down every other podman machine
+  # on the host. The match has to be scoped to transmission-vm.
+  run grep -A 12 '^reap_machine_helpers()' "${WRAPPER_SCRIPT}"
+  [[ "${output}" == *"transmission-vm"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Startup sequence
+# ---------------------------------------------------------------------------
+
+@test "a failed initial machine start does not silently fall through to container create" {
+  # Contributing factor in #168: ensure_machine's return value was ignored at
+  # the top-level call sites, so a machine failure surfaced later as a
+  # confusing container error.
+  run grep -A 6 '^wait_for_nfs || exit 1' "${WRAPPER_SCRIPT}"
+  [[ "${output}" == *"if ensure_machine; then"* ]]
+}
+
+@test "the loop refuses to start without timeout(1) rather than running unbounded" {
+  # A supervision loop that cannot bound its subprocesses cannot recover from a
+  # hang, which is the whole failure mode of #168. Exiting loudly beats running
+  # in a state that only looks supervised.
+  rm -f "${MOCK_BIN_DIR}/timeout"
+
+  run timeout 10 "${WRAPPER_SCRIPT}"
+
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"FATAL: timeout(1) not found"* ]]
+  [[ "${output}" == *"brew install coreutils"* ]]
+
+  # And it must bail before touching podman at all.
+  [ ! -s "${CALLS_FILE}" ]
 }

--- a/tests/transmission-post-start.bats
+++ b/tests/transmission-post-start.bats
@@ -157,3 +157,43 @@ teardown() {
   run grep -E 'PIA_PORT_DETACHED=1 setsid' "${POST_START}"
   [ "$status" -eq 0 ]
 }
+
+# --- startup log accuracy (#182) --------------------------------------------
+
+@test "the startup log does not report a region it cannot see" {
+  # The image's start.sh invokes this hook without exporting the container
+  # environment, so OPENVPN_CONFIG is never set here. Logging
+  # "region: ${OPENVPN_CONFIG:-unknown}" therefore printed "region: unknown" on
+  # every start and read as a misconfiguration during the 2026-08-23 incident.
+  # Strip comments first: OPENVPN_CONFIG is still named in the prose explaining
+  # why it cannot be used, and that mention should not fail the test.
+  run bash -c "grep -v '^[[:space:]]*#' \"${POST_START}\" | grep -c 'OPENVPN_CONFIG'"
+  [ "$output" -eq 0 ]
+}
+
+@test "the startup log reports the tunnel gateway, which is derived not inherited" {
+  run grep -E 'Starting PIA port forwarding manager \(tunnel gateway:' "${POST_START}"
+  [ "$status" -eq 0 ]
+
+  # The value must come from the routing table via pf_gateway, not from the
+  # environment — that is the whole point of the change.
+  run grep -E '^pf_gateway_or_unknown\(\)' "${POST_START}"
+  [ "$status" -eq 0 ]
+}
+
+@test "pf_gateway_or_unknown yields a placeholder before the tunnel exists" {
+  local script="${TEST_TMPDIR}/gw.sh"
+  # Extract just the two gateway helpers and exercise them with no tun route.
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'set -uo pipefail'
+    sed -n '/^pf_gateway() {/,/^}/p' "${POST_START}"
+    sed -n '/^pf_gateway_or_unknown() {/,/^}/p' "${POST_START}"
+    printf '%s\n' 'pf_gateway_or_unknown'
+  } >"${script}"
+
+  # `ip` is absent on macOS and returns no tun route in the sandbox either way.
+  run bash "${script}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "not yet established" ]
+}


### PR DESCRIPTION
Closes #182, closes #168, closes #181, closes #174. Addresses #179, #176, #171.
**#178 needs your decisions — see the bottom.**

## #182 — the log line was lying, and it cost a debugging detour

Mechanism confirmed, but the fix is not what the title implies. The hook
genuinely never sees `OPENVPN_CONFIG` — the image's `start.sh` does not export
the container environment — so `${OPENVPN_CONFIG:-unknown}` was falling back
**correctly**. The bug was the line misreporting state, which is worse than
being wrong: during the 2026-08-23 incident it read as a misconfiguration and
sent someone chasing a tunnel that had negotiated but passed no traffic.

Now logs the tunnel gateway, derived from the routing table rather than
inherited from the environment. It is always available, and it is the endpoint
the port-forwarding API is actually queried against — what connected, not what
was requested.

## #168 — every podman call is now bounded

Mechanism confirmed by reading the code: no `timeout` on any podman call in
the supervision loop, and `podman machine stop`'s exit code was taken as proof
its helpers had exited. `podman_t` now bounds every call, `reap_machine_helpers`
verifies helpers actually exited, and startup checks `ensure_machine`'s return.

The test asserts *no unbounded call survives* rather than enumerating the ones
fixed, so a newly added bare call fails the test instead of shipping.

## #181 — watchdog for silent port-forwarding loss

New `pia-port-watchdog.sh` (335 lines, 17 tests, LaunchAgent at 900s).

Two real bugs were caught in its own first draft, both worth recording:

- **`jq`'s `//` swallowed the reading that matters.** `.arguments["port-is-open"] // "unknown"`
  fires on `false` as well as `null`, so a genuine "port is closed" became
  "unknown" and never alerted — the watchdog would have been blind to the exact
  condition it exists to catch. Now an explicit `has()` check.
- **A `perl alarm` timeout fallback reintroduced the hang.** SIGALRM kills perl
  but leaves the command's children alive holding the pipe open, so
  `state=$(podman_t ... machine inspect)` blocks forever — #168's bug wearing a
  timeout. Removed; `timeout(1)` is required and the loop exits loudly without it.

## The alert pointed at a script that was never deployed

`pia-pf-probe.sh` was the only file in `app-setup/templates/` that no setup
script deployed. The watchdog's alert email ends with

```
ssh operator@tilsit ~/containers/transmission/scripts/pia-pf-probe.sh --all
```

— a path that did not exist on the operator account. An alert that sends you to
a missing file during an outage is worse than no alert. Now deployed.

## Test runner was not running most of the tests

`run_tests.sh` globbed only `tests/transmission-filebot/{unit,integration}`, so
the **eight** suites at `tests/*.bats` — 147 tests, including the 41 this branch
adds — were never executed by the project's own test command, or by CI, which
calls it. The new watchdog passed all 17 of its tests while `run_tests.sh`
reported success without loading the file.

Fixed with a third Component Tests group. Falsified: an injected failing
assertion propagates through `COMPONENT_RESULT` to a non-zero runner exit.

## Findings issues

- **#174 FIXED** — `tests/pia-pf-probe.bats` created (12 tests).
- **#171** — item 1 FIXED (real `mapfile` bug: `mapfile -t a <<<""` yields one
  empty element, so the "no regions" guard counted it as 1 and probed an empty
  region name). Item 2 FIXED. Item 4 cosmetic, deferred.
- **#179** — item 1 FIXED. Items 2 and 3 deferred (one needs a live container,
  the other self-describes as "No actual bug… noted for completeness").
- **#176 FIXED, premise stale** — both `panama` defaults corrected, but to
  `ca_vancouver`, not the `ca_toronto` the issue names; the template moved on
  in `cdbf06e`.

## Verification

- 147 top-level + 33 filebot tests pass; +41 tests, no regressions.
- **7 mutants**, each caught by the specific test that should catch it, template
  restored byte-identical after each: threshold 3→1, the jq `//` bug, dropping
  the `was_alerted` latch, counting unreachable RPC toward the streak, dropping
  the unreachable-port check, never re-arming after recovery, deleting the
  pf-probe copy.
- Both reviewers PASS on all five commits.
- Pre-push whole-codebase review run as a dry-run first: PASS. Both non-blocking
  findings checked and confirmed false positives — the `set -e` claim targets a
  script whose line 32 reads "Deliberately not `set -e`", and the "wrong function
  name" guard correctly matches `podman_t`'s body.

## Caveat worth your attention

The watchdog and the #168 timeout changes are verified **against mocks only**.
The RPC field names (`peer-port`, `port-is-open`) and the `gvproxy`/`vfkit` argv
matching in `reap_machine_helpers` are the two places worth a real check on
TILSIT before trusting them in production.

## #178 — NEEDS YOUR DECISIONS, not attempted

Five choices have to be made before any code, and guessing any of them produces
silent data loss on a media library:

1. The duplicate-matching key — filename, hash, or title/season/episode — and
   what "same content" means for multi-part rips and episode packs.
2. The quality-comparison priority order and tie-breakers. The issue says this
   must be admin-configurable; the ordering *is* the policy.
3. Quarantine location and retention window.
4. Which Plex library sections to rescan, and targeted vs full scan.
5. Where the hook lands relative to the existing `transmission-done.sh` (50KB)
   and `pending-move-cleanup.sh`.

## Follow-ups

- `tests/podman-machine-start.bats` — the `reap_machine_helpers` call-site test
  asserts `grep -c >= 3`, which passes silently if a call site is *moved* rather
  than added. A structural per-call-site grep would be firmer.
- Podman version drift itself is still unaddressed. `brew upgrade` replaces the
  CLI without cycling the VM; these changes make the mismatch recoverable, not
  impossible. #168's option 4 needs to know what runs scheduled `brew upgrade`
  on TILSIT.

https://claude.ai/code/session_014iwogYZxFU6NqXmiobcMMv