### PR TITLE
fix(pia): single-write heartbeat state, plus two tests that can fail

### DIFF
--- a/app-setup/templates/pia-port-watchdog.sh
+++ b/app-setup/templates/pia-port-watchdog.sh
@@ -191,23 +191,39 @@ send_email() {
 # Heartbeat
 # ---------------------------------------------------------------------------
 
+# Logs a heartbeat if one is due, and prints the timestamp the caller should
+# persist: the new one when it logged, the existing one otherwise.
+#
+# This deliberately does not write state itself. It used to, which meant the
+# healthy path wrote the state file twice per cycle — once here with a fresh
+# last_heartbeat but every other field stale from the previous cycle, then
+# again in main with the real values. Each write is atomic on its own, so the
+# file was never torn, but a kill landing between them left a state file
+# pairing a current heartbeat with last cycle's port and failure count. Main
+# then had to read its own heartbeat back off disk to carry it forward.
+#
+# Returning the value instead collapses that to a single write at the end of
+# the cycle, so state advances all at once or not at all.
 maybe_heartbeat() {
   local detail="$1"
-
-  local last_heartbeat
-  last_heartbeat=$(state_get "last_heartbeat" "1970-01-01T00:00:00Z")
+  local current="$2"
 
   local now_epoch last_epoch
   now_epoch=$(date +%s)
-  last_epoch=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "${last_heartbeat}" '+%s' 2>/dev/null) || last_epoch=0
+  last_epoch=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "${current}" '+%s' 2>/dev/null) || last_epoch=0
 
   if [[ $((now_epoch - last_epoch)) -ge ${HEARTBEAT_INTERVAL_SECONDS} ]]; then
     log "OK: ${detail}"
-    local now state
-    now=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-    state=$(read_state | jq --arg lh "${now}" '.last_heartbeat = $lh')
-    write_state "${state}"
+    date -u '+%Y-%m-%dT%H:%M:%SZ'
+    return 0
   fi
+
+  # Suppressed, not failed: carrying the existing timestamp forward is the
+  # normal outcome for all but one cycle an hour. Return explicitly so the
+  # status is the function's own contract rather than whatever printf last
+  # happened to return.
+  printf '%s' "${current}"
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -250,6 +266,12 @@ main() {
 
   local now
   now=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+  # Read the existing heartbeat once, here. maybe_heartbeat either hands it
+  # back unchanged or returns a fresh one; either way the single write at the
+  # end of this function persists whatever it returned.
+  local heartbeat
+  heartbeat="$(state_get "last_heartbeat" "1970-01-01T00:00:00Z")"
 
   if [[ "${bad}" == "true" ]]; then
     failures=$((failures + 1))
@@ -303,11 +325,8 @@ No action required." || true
     fi
     was_alerted=false
     failures=0
-    maybe_heartbeat "peer port ${port}, reachable: ${open}"
+    heartbeat="$(maybe_heartbeat "peer port ${port}, reachable: ${open}" "${heartbeat}")"
   fi
-
-  local heartbeat
-  heartbeat="$(state_get "last_heartbeat" "${now}")"
 
   local new_state
   new_state=$(jq -n \

--- a/tests/pia-port-guard.bats
+++ b/tests/pia-port-guard.bats
@@ -23,6 +23,23 @@ setup() {
   export CALL_LOG="${TEST_TMPDIR}/calls.log"
   touch "${CALL_LOG}"
 
+  # Companion log holding one argument per line, recorded only for the call
+  # that sets the port. Two properties matter, and both are needed:
+  #
+  #   One argument per line -- CALL_LOG joins with "$*", which is convenient
+  #   for adjacency assertions ("-p 54321") but blind to argument boundaries:
+  #   one argument containing spaces and four separate arguments render as the
+  #   same bytes. Only a one-per-line record can tell them apart, and it does
+  #   so regardless of what IFS happens to be.
+  #
+  #   Scoped to the port-setting call -- apply_port calls transmission-remote
+  #   more than once (current_peer_port runs first). A log accumulated across
+  #   every call lets a correctly-quoted -si call satisfy an assertion aimed
+  #   at a broken -p call, so the test passes on word-split code. Recording
+  #   only the -p invocation keeps the assertion pointed at its subject.
+  export ARG_LOG="${TEST_TMPDIR}/args.log"
+  touch "${ARG_LOG}"
+
   # Port reported by the stub's -si output; tests override to simulate the
   # daemon's current state.
   export STUB_CURRENT_PORT="33361"
@@ -36,6 +53,9 @@ for arg in "$@"; do
     exit 0
   fi
 done
+# Anything past the -si branch is the port-setting call. Record its arguments
+# one per line so word-splitting assertions see only this invocation.
+printf '%s\n' "$@" >>"${ARG_LOG}"
 exit 0
 STUB
   chmod +x "${TEST_TMPDIR}/transmission-remote"
@@ -157,14 +177,19 @@ teardown() {
   export STUB_CURRENT_PORT="33361"
   run apply_port 54321 "http://localhost:9091/transmission/rpc" --auth "user:pass with spaces"
   [ "$status" -eq 0 ]
-  grep -q -- "--auth user:pass with spaces" "${CALL_LOG}"
+  # Assert on ARG_LOG, not CALL_LOG: one line per argument means the credential
+  # arriving whole is distinguishable from it being split into four arguments.
+  # A "$*"-joined line renders both cases identically, so it cannot catch the
+  # regression this test exists for.
+  grep -qx -- "--auth" "${ARG_LOG}"
+  grep -qx -- "user:pass with spaces" "${ARG_LOG}"
 }
 
 @test "apply_port works with no auth arguments supplied" {
   export STUB_CURRENT_PORT="33361"
   run apply_port 54321 "http://localhost:9091/transmission/rpc"
   [ "$status" -eq 0 ]
-  ! grep -q -- "--auth" "${CALL_LOG}"
+  ! grep -qx -- "--auth" "${ARG_LOG}"
 }
 
 # --- idempotency ------------------------------------------------------------

--- a/tests/pia-port-watchdog.bats
+++ b/tests/pia-port-watchdog.bats
@@ -392,3 +392,92 @@ watchdog_log() {
     "${REPO_DIR}/app-setup/podman-transmission-setup.sh"
   [ "$status" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# Heartbeat state writes (#184)
+#
+# The healthy path used to write the state file twice per cycle: once inside
+# maybe_heartbeat with a fresh last_heartbeat but every other field still
+# holding the previous cycle's values, then again in main with the real ones.
+# Individually each write is atomic, so the file was never torn — but a kill
+# landing between them persisted a current heartbeat next to a stale port and
+# failure count. maybe_heartbeat now returns the timestamp instead of storing
+# it, so a cycle's state advances in one write or not at all.
+# ---------------------------------------------------------------------------
+
+@test "maybe_heartbeat does not write state itself" {
+  # Structural: the whole point of the change is that this function has no
+  # write_state call left in it. Behavioural tests below cannot distinguish
+  # one write from two, so assert on the function body directly.
+  #
+  # Ask bash for the body via declare -f rather than slicing the file with
+  # awk. A text extractor has to guess where the function ends, and every
+  # cheap guess ("the next } at column 0") breaks the day someone adds a case
+  # statement or a nested block closed in column 0: the extract silently comes
+  # back truncated, write_state is missing from the part that was read, and
+  # this test goes green for the wrong reason. bash has already parsed the
+  # function, so it knows the real boundaries.
+  local body
+  body="$(TEST_RUNNER=true bash -c \
+    'source "$1" >/dev/null 2>&1; declare -f maybe_heartbeat' _ "${WATCHDOG}")"
+
+  # Guard the guard: an empty body would make the assertion below vacuous.
+  [ -n "${body}" ]
+  grep -q 'maybe_heartbeat' <<<"${body}"
+  ! grep -q 'write_state' <<<"${body}"
+}
+
+@test "a healthy cycle records a heartbeat and the current port together" {
+  set_rpc "51413" "true"
+
+  run run_cycle
+  [ "$status" -eq 0 ]
+
+  # One consistent snapshot: the heartbeat is real, and it sits next to this
+  # cycle's port rather than a previous cycle's.
+  [ "$(state_field '.last_heartbeat')" != "null" ]
+  [ "$(state_field '.last_heartbeat')" != "1970-01-01T00:00:00Z" ]
+  [ "$(state_field '.peer_port')" = "51413" ]
+  [ "$(state_field '.port_is_open')" = "yes" ]
+}
+
+@test "a heartbeat inside the interval is not rewritten" {
+  set_rpc "51413" "true"
+  run_cycle
+  local first
+  first="$(state_field '.last_heartbeat')"
+
+  # HEARTBEAT_INTERVAL_SECONDS is an hour, so an immediate second cycle is
+  # well inside it: the timestamp must survive unchanged rather than being
+  # refreshed or dropped.
+  set_rpc "51414" "true"
+  run run_cycle
+  [ "$status" -eq 0 ]
+  [ "$(state_field '.last_heartbeat')" = "${first}" ]
+
+  # ...while the rest of the cycle's data still advances.
+  [ "$(state_field '.peer_port')" = "51414" ]
+}
+
+@test "a bad cycle does not invent a heartbeat it never logged" {
+  # The old code defaulted the carried-forward value to now, so a first cycle
+  # that found the port broken wrote a heartbeat that never happened — which
+  # then suppressed the first real one for a full interval.
+  set_rpc "0" "false"
+
+  run run_cycle
+  [ "$status" -eq 0 ]
+  [ "$(state_field '.last_heartbeat')" = "1970-01-01T00:00:00Z" ]
+  ! grep -q 'OK: peer port' <<<"$(watchdog_log)"
+}
+
+@test "the first healthy cycle after a bad one logs its heartbeat immediately" {
+  set_rpc "0" "false"
+  run_cycle
+
+  set_rpc "51413" "true"
+  run run_cycle
+  [ "$status" -eq 0 ]
+  [ "$(state_field '.last_heartbeat')" != "1970-01-01T00:00:00Z" ]
+  grep -q 'OK: peer port 51413' <<<"$(watchdog_log)"
+}

--- a/tests/podman-machine-start.bats
+++ b/tests/podman-machine-start.bats
@@ -119,7 +119,7 @@ extract_and_render_wrapper() {
   # the mocks first.
   export HOSTNAME_LOWER="testhost"
   export HOST_PORT="9091"
-  export PIA_REGION="panama"
+  export PIA_REGION="ca_vancouver"
   export LAN="192.168.1.0/24"
   export PUID="501"
   export PGID="20"


### PR DESCRIPTION
## Summary

Works the remaining pre-push review findings (#171, #176, #179, #184).

Most of the 11 findings described code that had already been fixed in #175,
#177, #180 and #185. The whole-codebase reviewer re-reads the entire tree on
every push, so it keeps re-reporting concerns that later commits resolved.
Checking each claim against the tree first reduced 11 findings to 3 real ones.

## What changed

**`pia-port-watchdog.sh` — single-write heartbeat state (#184)**

`maybe_heartbeat` no longer writes state. The healthy path used to write the
state file twice per cycle: once inside the function with a fresh
`last_heartbeat` but every other field still holding the previous cycle's
values, then again in `main` with the real ones. Each write is atomic on its
own, so the file was never torn — but a kill landing between them persisted a
current heartbeat next to a stale port and failure count. `main` also had to
read its own heartbeat back off disk to carry it forward. The function now
returns the timestamp, collapsing this to one write per cycle.

This also fixes a latent bug the review did not catch: the old carried-forward
default was `now`, so a first cycle that found the port broken recorded a
heartbeat that never happened, suppressing the first real one for a full hour.

**`pia-port-guard.bats` — an assertion that can actually fail (#171)**

The word-splitting test asserted against a log built with `"$*"`, which joins
arguments — rendering one argument containing spaces identically to four
separate ones, the exact distinction the test exists to make. Arguments are
now recorded one per line, scoped to the port-setting call.

Scoping mattered as much as the format: `apply_port` calls
`transmission-remote` more than once, and an accumulated log let a correctly
quoted `-si` call satisfy an assertion aimed at a broken `-p` call. The first
version of this fix passed against deliberately sabotaged code and was
rewritten.

**`podman-machine-start.bats` — fixture region (#184)**

`panama` -> `ca_vancouver`, matching the deployment default. No test behaviour
depends on the value.

## Findings closed without code changes

Each was checked rather than assumed:

- **`setsid` availability in the container (#179)** — present at
  `/usr/bin/setsid` from `util-linux` on Ubuntu 22.04.5; the detached manager
  is running in its own session on the live host.
- **`pia-pf-probe.sh` in `templates/` without placeholders (#171)** — it
  belongs there. `podman-transmission-setup.sh:460-461` deploys it to the
  container's `scripts/` dir, which `tests/pia-port-watchdog.bats` already
  asserts. The finding's premise ("find no setup script that deploys it") is
  incorrect.
- **`pf_port` logging race (#179)** — the finding's own text concludes there
  is no bug.
- **Already fixed before this branch**: `mapfile` empty-array guard,
  `pia-pf-probe` BATS coverage (287 lines, 12 tests), README region default,
  setup-script region fallback, and the GNU `date` note.

## Verification

- Full suite: **303 assertions pass** (5 new tests added)
- `shellcheck -S info` and `shfmt -d -i 2 -ci -bn` clean
- Dry-run pre-push codebase review run twice, both **PASS**; findings from the
  first pass were fixed in-branch rather than left to be filed as new issues
- Every new assertion validated against deliberately broken code — unquoted
  `"${auth[@]}"` in the guard, and the previous two-write `maybe_heartbeat`.
  Each fails there and passes here.

Closes #171
Closes #176
Closes #179
Closes #184

https://claude.ai/code/session_015pHBKtjHYArgVfUtC74m6x
