### PR TITLE
feat(transmission-filebot): keep the better copy when a download duplicates media

### DIFF
--- a/app-setup/templates/media-compare.sh
+++ b/app-setup/templates/media-compare.sh
@@ -1,0 +1,479 @@
+# shellcheck shell=bash
+#
+# media-compare.sh — decide which of two copies of the same media to keep
+#
+# This is a sourced library, not an executable script; it defines functions and
+# runs nothing on its own.
+#
+# When FileBot renames a download onto a path that already holds a file, it is
+# run with `--conflict auto`, which skips rather than overwrites. The download
+# is then classified `already-in-plex` and moved to triage for a human to look
+# at (see classify_failure and triage_failed_torrent in transmission-done.sh).
+# Nothing is lost and nothing good is overwritten, but nothing is decided
+# either: the better copy sits in triage until somebody compares them by hand.
+#
+# This library makes that comparison. It reads objective attributes with
+# ffprobe and applies a fixed ladder of rules, so the same two files always
+# produce the same answer (issue #178).
+#
+# Deliberately NOT a general "which file is better" oracle. It answers one
+# narrow question — this download versus the library copy of the same title —
+# and answers "keep what we have" whenever it cannot tell. A wrong "replace"
+# costs the better copy; a wrong "keep" costs disk space and a triage entry.
+# Those are not symmetric, so every uncertain path resolves to keep.
+#
+# Usage (from transmission-done.sh):
+#     source "${SCRIPT_DIR}/media-compare.sh"
+#     decision="$(compare_media "${candidate}" "${incumbent}")"
+#
+# Author: Andrew Rich <andrew.rich@gmail.com>
+# Created: 2026-08-25
+
+# ---------------------------------------------------------------------------
+# Configuration
+#
+# Deliberately not `readonly`: transmission-done.sh may be sourced more than
+# once by the BATS helper, and re-sourcing a readonly assignment aborts the
+# caller under `set -e` — the same reason pia-port-guard.sh avoids them.
+# ---------------------------------------------------------------------------
+
+# ffprobe ships in the ffmpeg keg, which config/formulae.txt already installs.
+# Full path for the same reason FILEBOT and YQ use one: Transmission invokes
+# its done-script with a minimal PATH that does not include Homebrew.
+MEDIA_COMPARE_FFPROBE="${MEDIA_COMPARE_FFPROBE:-${HOMEBREW_PREFIX:-/opt/homebrew}/bin/ffprobe}"
+
+# ffprobe on a large file over NFS can block. Bound it: a comparison that
+# cannot be made in time resolves to "keep", which is the safe direction.
+MEDIA_COMPARE_TIMEOUT="${MEDIA_COMPARE_TIMEOUT:-30}"
+
+# Bitrate readings vary between two encodes of identical quality, and a
+# difference under this fraction is noise rather than signal. 10% keeps the
+# rule from flapping on files that are effectively the same.
+MEDIA_COMPARE_BITRATE_MARGIN="${MEDIA_COMPARE_BITRATE_MARGIN:-10}"
+
+# Log-only mode. When true, callers report what they would have done and change
+# nothing. The issue asks for this for initial rollout.
+MEDIA_COMPARE_DRY_RUN="${MEDIA_COMPARE_DRY_RUN:-false}"
+
+# How long a displaced file stays in quarantine before it may be reaped.
+MEDIA_COMPARE_RETENTION_DAYS="${MEDIA_COMPARE_RETENTION_DAYS:-14}"
+
+# ---------------------------------------------------------------------------
+# Attribute extraction
+# ---------------------------------------------------------------------------
+
+# Print one ffprobe field for a file, or nothing if it cannot be read.
+#
+# Every failure mode collapses to empty output: missing file, missing ffprobe,
+# timeout, unparsable container, or a field ffprobe reports as "N/A". Callers
+# treat empty as "unknown" and fall through to the next rule, so a partially
+# readable file still gets compared on whatever did resolve.
+media_probe_field() {
+  local file="$1"
+  local stream_spec="$2"
+  local entry="$3"
+
+  [[ -f "${file}" ]] || return 1
+  [[ -x "${MEDIA_COMPARE_FFPROBE}" ]] || return 1
+
+  # `|| true` is the point, not an oversight: every ffprobe failure -- timeout,
+  # unreadable container, unknown stream -- must surface as empty output for the
+  # caller to treat as "unknown", not as a non-zero status that would abort a
+  # caller running under `set -e`.
+  local raw
+  raw="$(timeout "${MEDIA_COMPARE_TIMEOUT}" "${MEDIA_COMPARE_FFPROBE}" \
+    -v error \
+    -select_streams "${stream_spec}" \
+    -show_entries "${entry}" \
+    -of default=noprint_wrappers=1:nokey=1 \
+    "${file}" 2>/dev/null | head -1 || true)"
+
+  # ffprobe prints the literal string N/A for a field it knows about but cannot
+  # fill in. That is not a number, and must not be compared as one.
+  [[ -n "${raw}" && "${raw}" != "N/A" ]] || return 1
+
+  printf '%s' "${raw}"
+}
+
+# Pixel count of the primary video stream — width * height rather than height
+# alone, so anamorphic and letterboxed encodes compare on actual picture area.
+media_resolution() {
+  local file="$1"
+  local width height
+  width="$(media_probe_field "${file}" "v:0" "stream=width")" || return 1
+  height="$(media_probe_field "${file}" "v:0" "stream=height")" || return 1
+  [[ "${width}" =~ ^[0-9]+$ && "${height}" =~ ^[0-9]+$ ]] || return 1
+  printf '%s' "$((width * height))"
+}
+
+# Video bitrate in bits/sec.
+#
+# Falls back to the container's overall bitrate when the stream does not carry
+# its own — common in Matroska, which often omits per-stream bitrate. The
+# fallback is only meaningful against another file measured the same way, which
+# is why the caller compares like with like and skips the rule if either side
+# is unknown.
+media_video_bitrate() {
+  local file="$1"
+  local rate
+  if rate="$(media_probe_field "${file}" "v:0" "stream=bit_rate")" \
+    && [[ "${rate}" =~ ^[0-9]+$ ]]; then
+    printf '%s' "${rate}"
+    return 0
+  fi
+  if rate="$(media_probe_field "${file}" "v:0" "format=bit_rate")" \
+    && [[ "${rate}" =~ ^[0-9]+$ ]]; then
+    printf '%s' "${rate}"
+    return 0
+  fi
+  return 1
+}
+
+# Channel count of the primary audio stream (2 for stereo, 6 for 5.1).
+media_audio_channels() {
+  local file="$1"
+  local channels
+  channels="$(media_probe_field "${file}" "a:0" "stream=channels")" || return 1
+  [[ "${channels}" =~ ^[0-9]+$ ]] || return 1
+  printf '%s' "${channels}"
+}
+
+# Size in bytes. stat is BSD here; the container never runs this library.
+media_file_size() {
+  local file="$1"
+  [[ -f "${file}" ]] || return 1
+  stat -f%z "${file}" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Pairing a download with the library file it duplicates
+# ---------------------------------------------------------------------------
+
+# Read FileBot's conflict output and print `source<TAB>destination` for each
+# skipped file, one pair per line.
+#
+# FileBot has already done the hard part. It matched the download to a title
+# and worked out exactly which library path it collides with, then named both
+# in the message it prints when `--conflict auto` declines to overwrite. Taking
+# the pair from that message is authoritative; guessing it back from filenames
+# is not. Anything this cannot parse yields no line, and the caller falls
+# through to the existing triage behaviour.
+#
+# Two formats, with the paths in opposite orders:
+#   [AUTO] Skipped [SOURCE] because [DEST] already exists
+#   [IMPORT] Destination file already exists: DEST (SOURCE)
+#
+# The IMPORT form is genuinely ambiguous: `DEST (SOURCE)` cannot be split by
+# pattern alone once both paths contain " (", which is routine for films —
+# `/plex/The Thing (1982).mkv (/dl/The Thing (1982).mkv)` has three candidate
+# split points and a greedy regex picks the wrong one, pairing a fragment of
+# one path with a fragment of the other. Comparing and quarantining the wrong
+# library file is the worst outcome this library can produce, so that case is
+# resolved by checking the filesystem rather than by guessing: try each split
+# and keep the one where both sides are real files.
+parse_filebot_conflicts() {
+  local filebot_output="$1"
+
+  # The AUTO form is unambiguous -- both paths are bracket-delimited.
+  printf '%s\n' "${filebot_output}" | sed -n \
+    -e 's/^.*Skipped \[\(.*\)\] because \[\(.*\)\] already exists.*$/\1	\2/p'
+
+  local line
+  while IFS= read -r line; do
+    [[ "${line}" == *"Destination file already exists: "* ]] || continue
+    _emit_import_conflict "${line}"
+  done <<<"${filebot_output}"
+}
+
+# Split one IMPORT-format line into `source<TAB>destination`, printing nothing
+# if no split can be justified.
+_emit_import_conflict() {
+  local rest="${1#*Destination file already exists: }"
+  rest="${rest%)}"
+
+  # Walk the candidate split points left to right and take the first where both
+  # halves name existing files. In production they always do -- FileBot just
+  # looked at both of them.
+  local probe="${rest}" prefix="" dest src
+  while [[ "${probe}" == *" ("* ]]; do
+    dest="${prefix}${probe%% (*}"
+    src="${probe#* (}"
+    if [[ -f "${dest}" && -f "${src}" ]]; then
+      printf '%s\t%s\n' "${src}" "${dest}"
+      return 0
+    fi
+    prefix="${dest} ("
+    probe="${src}"
+  done
+
+  # Nothing validated -- either the files are gone, or this is a unit test with
+  # synthetic paths. Fall back to the simple split, which is correct whenever
+  # only one candidate point exists. A pair that is wrong here still cannot
+  # destroy anything: compare_media requires both files to be readable, and
+  # answers "keep" when either is not.
+  if [[ "${rest}" == *" ("* ]]; then
+    printf '%s\t%s\n' "${rest##* (}" "${rest% (*}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+# Compare two files that hold the same title and print a verdict:
+#
+#   replace   the candidate is better; the incumbent should be displaced
+#   keep      the incumbent is better, identical, or the answer is unclear
+#
+# The reason is printed on a second line so callers can log why. Rules are
+# applied in order and the first one that separates the files decides:
+#
+#   1. identical bytes    -> keep (nothing to gain, and a hash is conclusive)
+#   2. resolution         -> more pixels wins
+#   3. video bitrate      -> higher wins, past a noise margin
+#   4. audio channels     -> more wins
+#   5. size               -> larger wins, as a last resort
+#
+# Two files that tie on every rule return keep: with no evidence of an
+# improvement, churning the library is the worse option.
+compare_media() {
+  local candidate="$1"
+  local incumbent="$2"
+
+  if [[ ! -f "${candidate}" ]]; then
+    printf 'keep\ncandidate is not a readable file\n'
+    return 0
+  fi
+  if [[ ! -f "${incumbent}" ]]; then
+    # Nothing to compare against. Callers treat this as "no duplicate", but
+    # answering "replace" here would be a claim this function cannot support.
+    printf 'keep\nincumbent is not a readable file\n'
+    return 0
+  fi
+
+  # Rule 1: identical content. Compare sizes first — cmp on two large files
+  # over NFS is expensive, and differing sizes rule out identity outright.
+  local cand_size inc_size
+  cand_size="$(media_file_size "${candidate}")" || cand_size=""
+  inc_size="$(media_file_size "${incumbent}")" || inc_size=""
+  if [[ -n "${cand_size}" && "${cand_size}" == "${inc_size}" ]]; then
+    if cmp -s "${candidate}" "${incumbent}"; then
+      printf 'keep\nidentical file (byte-for-byte)\n'
+      return 0
+    fi
+  fi
+
+  # Rule 2: resolution.
+  local cand_res inc_res
+  cand_res="$(media_resolution "${candidate}")" || cand_res=""
+  inc_res="$(media_resolution "${incumbent}")" || inc_res=""
+  if [[ -n "${cand_res}" && -n "${inc_res}" && "${cand_res}" -ne "${inc_res}" ]]; then
+    if [[ "${cand_res}" -gt "${inc_res}" ]]; then
+      printf 'replace\nhigher resolution (%s vs %s pixels)\n' "${cand_res}" "${inc_res}"
+    else
+      printf 'keep\nlower resolution (%s vs %s pixels)\n' "${cand_res}" "${inc_res}"
+    fi
+    return 0
+  fi
+
+  # Rule 3: video bitrate, past the noise margin. Integer arithmetic only —
+  # this runs under Transmission's shell, where bc may not exist.
+  local cand_rate inc_rate
+  cand_rate="$(media_video_bitrate "${candidate}")" || cand_rate=""
+  inc_rate="$(media_video_bitrate "${incumbent}")" || inc_rate=""
+  if [[ -n "${cand_rate}" && -n "${inc_rate}" ]]; then
+    local margin=$((inc_rate * MEDIA_COMPARE_BITRATE_MARGIN / 100))
+    if [[ "${cand_rate}" -gt $((inc_rate + margin)) ]]; then
+      printf 'replace\nhigher video bitrate (%s vs %s bps)\n' "${cand_rate}" "${inc_rate}"
+      return 0
+    fi
+    if [[ "${inc_rate}" -gt $((cand_rate + margin)) ]]; then
+      printf 'keep\nlower video bitrate (%s vs %s bps)\n' "${cand_rate}" "${inc_rate}"
+      return 0
+    fi
+  fi
+
+  # Rule 4: audio channels.
+  local cand_ch inc_ch
+  cand_ch="$(media_audio_channels "${candidate}")" || cand_ch=""
+  inc_ch="$(media_audio_channels "${incumbent}")" || inc_ch=""
+  if [[ -n "${cand_ch}" && -n "${inc_ch}" && "${cand_ch}" -ne "${inc_ch}" ]]; then
+    if [[ "${cand_ch}" -gt "${inc_ch}" ]]; then
+      printf 'replace\nmore audio channels (%s vs %s)\n' "${cand_ch}" "${inc_ch}"
+    else
+      printf 'keep\nfewer audio channels (%s vs %s)\n' "${cand_ch}" "${inc_ch}"
+    fi
+    return 0
+  fi
+
+  # Rule 5: size, as a tiebreak. Only meaningful once the rules above found
+  # nothing, so it never overrides a real quality signal.
+  if [[ -n "${cand_size}" && -n "${inc_size}" && "${cand_size}" -ne "${inc_size}" ]]; then
+    if [[ "${cand_size}" -gt "${inc_size}" ]]; then
+      printf 'replace\nlarger file (%s vs %s bytes)\n' "${cand_size}" "${inc_size}"
+    else
+      printf 'keep\nsmaller file (%s vs %s bytes)\n' "${cand_size}" "${inc_size}"
+    fi
+    return 0
+  fi
+
+  printf 'keep\nno measurable difference\n'
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Replacement
+# ---------------------------------------------------------------------------
+
+# Move the incumbent into quarantine and put the candidate in its place.
+#
+# Order matters and is not interchangeable. The incumbent is moved out first,
+# so the library never holds two files for one slot; then the candidate is
+# moved in. If the second move fails, the incumbent is restored — better to
+# end where we started than to leave the library missing an episode.
+#
+# `mv` within one filesystem is atomic, so a reader either sees the old file or
+# the new one. Across filesystems (the NAS is a separate mount) mv copies and
+# unlinks, which is not atomic; the restore path is what covers that case.
+replace_media_file() {
+  local candidate="$1"
+  local incumbent="$2"
+  local quarantine_dir="$3"
+
+  if [[ ! -f "${candidate}" ]]; then
+    media_compare_log "Replace aborted: candidate missing (${candidate})"
+    return 1
+  fi
+  if [[ ! -f "${incumbent}" ]]; then
+    media_compare_log "Replace aborted: incumbent missing (${incumbent})"
+    return 1
+  fi
+
+  if [[ "${MEDIA_COMPARE_DRY_RUN}" == "true" ]]; then
+    media_compare_log "DRY RUN: would replace ${incumbent} with ${candidate}"
+    return 0
+  fi
+
+  mkdir -p "${quarantine_dir}" 2>/dev/null || {
+    media_compare_log "Replace aborted: cannot create quarantine ${quarantine_dir}"
+    return 1
+  }
+
+  # Timestamp the quarantined name so repeated replacements of the same title
+  # do not overwrite each other — the whole point of quarantine is that the
+  # displaced file is still there to recover.
+  local incumbent_name quarantined
+  incumbent_name="$(basename "${incumbent}")"
+  quarantined="${quarantine_dir}/${incumbent_name}.$(date +%Y%m%d-%H%M%S)"
+
+  if ! mv "${incumbent}" "${quarantined}" 2>/dev/null; then
+    media_compare_log "Replace aborted: could not quarantine ${incumbent}"
+    return 1
+  fi
+
+  if ! mv "${candidate}" "${incumbent}" 2>/dev/null; then
+    media_compare_log "Replace failed mid-way: restoring ${incumbent} from quarantine"
+    if mv "${quarantined}" "${incumbent}" 2>/dev/null; then
+      media_compare_log "Restored ${incumbent}; library is unchanged"
+    else
+      # Both moves failed. Say so loudly and name the file, because this is the
+      # one path that leaves the library short an episode.
+      media_compare_log "ERROR: ${incumbent} is missing; the original is at ${quarantined}"
+    fi
+    return 1
+  fi
+
+  media_compare_log "Replaced ${incumbent} (previous copy quarantined at ${quarantined})"
+  return 0
+}
+
+# Delete quarantined files older than the retention window.
+#
+# Scoped to the quarantine directory and to regular files, and takes the
+# directory as an argument rather than deriving it, so a caller cannot
+# accidentally point this at a library path.
+prune_quarantine() {
+  local quarantine_dir="$1"
+  local retention_days="${2:-${MEDIA_COMPARE_RETENTION_DAYS}}"
+
+  [[ -d "${quarantine_dir}" ]] || return 0
+
+  if [[ "${MEDIA_COMPARE_DRY_RUN}" == "true" ]]; then
+    local due
+    due="$(find "${quarantine_dir}" -type f -mtime "+${retention_days}" 2>/dev/null | wc -l | tr -d ' ' || true)"
+    media_compare_log "DRY RUN: ${due} quarantined file(s) past ${retention_days}d retention"
+    return 0
+  fi
+
+  local pruned=0
+  while IFS= read -r stale; do
+    [[ -n "${stale}" ]] || continue
+    if rm -f "${stale}" 2>/dev/null; then
+      pruned=$((pruned + 1))
+    fi
+  done < <(find "${quarantine_dir}" -type f -mtime "+${retention_days}" 2>/dev/null || true)
+
+  if [[ "${pruned}" -gt 0 ]]; then
+    media_compare_log "Pruned ${pruned} quarantined file(s) older than ${retention_days} days"
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Logging
+#
+# transmission-done.sh defines log(); when sourced from there this delegates to
+# it so decisions land in the same processing log as everything else. Standalone
+# (tests, manual runs) it falls back to stderr rather than failing.
+# ---------------------------------------------------------------------------
+media_compare_log() {
+  if declare -F log >/dev/null 2>&1; then
+    log "$1"
+  else
+    printf '[media-compare] %s\n' "$1" >&2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+# Work every conflict FileBot reported, replacing library files that the
+# download improves on.
+#
+# Prints the number of replacements made, so the caller knows whether a Plex
+# rescan is warranted -- a scan with nothing to find is wasted work, and this
+# runs on every duplicate.
+#
+# Returns 0 whether or not anything was replaced. A duplicate that loses the
+# comparison is a normal outcome, not a failure, and the download still goes to
+# triage either way.
+process_duplicate_conflicts() {
+  local filebot_output="$1"
+  local quarantine_dir="$2"
+
+  local replaced=0
+  local candidate incumbent
+
+  while IFS=$'\t' read -r candidate incumbent; do
+    [[ -n "${candidate}" && -n "${incumbent}" ]] || continue
+
+    local result verdict why
+    result="$(compare_media "${candidate}" "${incumbent}")"
+    verdict="$(printf '%s' "${result}" | head -1)"
+    why="$(printf '%s' "${result}" | sed -n '2p')"
+
+    if [[ "${verdict}" != "replace" ]]; then
+      media_compare_log "Keeping library copy of $(basename "${incumbent}"): ${why}"
+      continue
+    fi
+
+    media_compare_log "Upgrading $(basename "${incumbent}"): ${why}"
+    if replace_media_file "${candidate}" "${incumbent}" "${quarantine_dir}"; then
+      replaced=$((replaced + 1))
+    fi
+  done < <(parse_filebot_conflicts "${filebot_output}" || true)
+
+  printf '%s' "${replaced}"
+  return 0
+}

--- a/app-setup/templates/media-compare.sh
+++ b/app-setup/templates/media-compare.sh
@@ -366,6 +366,21 @@ replace_media_file() {
   incumbent_name="$(basename "${incumbent}")"
   quarantined="${quarantine_dir}/${incumbent_name}.$(date +%Y%m%d-%H%M%S)"
 
+  # A second-granularity timestamp is not unique on its own: an episode pack
+  # replacing several files named alike can land twice in the same second, and
+  # the second move would overwrite the first copy in quarantine -- destroying
+  # the very file quarantine exists to preserve. Step aside if the name is
+  # taken rather than clobbering it.
+  local attempt=1
+  while [[ -e "${quarantined}" ]]; do
+    quarantined="${quarantine_dir}/${incumbent_name}.$(date +%Y%m%d-%H%M%S).${attempt}"
+    attempt=$((attempt + 1))
+    if [[ "${attempt}" -gt 100 ]]; then
+      media_compare_log "Replace aborted: cannot find a free quarantine name for ${incumbent_name}"
+      return 1
+    fi
+  done
+
   if ! mv "${incumbent}" "${quarantined}" 2>/dev/null; then
     media_compare_log "Replace aborted: could not quarantine ${incumbent}"
     return 1

--- a/app-setup/templates/transmission-done.sh
+++ b/app-setup/templates/transmission-done.sh
@@ -74,6 +74,14 @@ done
 SCRIPT_DIR="$(cd -P "$(dirname "${SCRIPT_SOURCE}")" && pwd)"
 readonly SCRIPT_DIR
 
+# Duplicate-quality comparison (#178). Optional: if the library is absent the
+# script keeps its previous behaviour of triaging every duplicate for a human,
+# rather than failing over a feature that only refines an already-safe path.
+if [[ -f "${SCRIPT_DIR}/media-compare.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "${SCRIPT_DIR}/media-compare.sh"
+fi
+
 # Derive HOME from script path (assumes script is in user's home directory tree)
 if [[ "${SCRIPT_DIR}" =~ ^(/Users/[^/]+) ]]; then
   DERIVED_HOME="${BASH_REMATCH[1]}"
@@ -1293,6 +1301,13 @@ process_media() {
     if [[ "${INVOCATION_MODE}" == "automated" ]]; then
       local category
       category=$(classify_failure "${LAST_PREVIEW_OUTPUT:-${LAST_FILEBOT_OUTPUT:-}}")
+      # Preview runs with --action test, which reports [TEST] lines rather than
+      # the conflict messages that name both paths. So this call normally finds
+      # no pair and does nothing -- which is the correct outcome, not a missed
+      # one: with no way to identify the library file, the download belongs in
+      # triage. It is called here anyway so both triage sites behave the same
+      # way if FileBot ever does report a conflict during preview.
+      handle_duplicate_upgrades "${category}" "${LAST_PREVIEW_OUTPUT:-${LAST_FILEBOT_OUTPUT:-}}"
       local triage_base="${TR_TORRENT_DIR%/*}/triage"
       if triage_failed_torrent "${source_dir}" "${category}" "${triage_base}"; then
         return 0
@@ -1319,6 +1334,7 @@ process_media() {
     if [[ "${INVOCATION_MODE}" == "automated" ]]; then
       local category
       category=$(classify_failure "${LAST_FILEBOT_OUTPUT}")
+      handle_duplicate_upgrades "${category}" "${LAST_FILEBOT_OUTPUT}"
       local triage_base="${TR_TORRENT_DIR%/*}/triage"
       if triage_failed_torrent "${source_dir}" "${category}" "${triage_base}"; then
         # Return 0: the torrent is "handled" (triaged), trigger watcher should
@@ -1399,6 +1415,58 @@ cleanup_empty_dirs() {
       fi
     done
   done
+}
+
+# Upgrade library files this download improves on, before it goes to triage.
+#
+# Only runs for the already-in-plex category: every other failure means FileBot
+# never worked out which library file the download collides with, so there is
+# nothing to compare against. A download that loses the comparison, or that
+# cannot be compared at all, still goes to triage exactly as before — this only
+# adds the case where the new copy is measurably better.
+#
+# Args: $1=category (from classify_failure), $2=FileBot output
+# Returns 0 always; a comparison that changes nothing is a normal outcome.
+handle_duplicate_upgrades() {
+  local category="$1"
+  local filebot_output="$2"
+
+  [[ "${category}" == "already-in-plex" ]] || return 0
+
+  # media-compare.sh is sourced only when present, so a deployment without it
+  # keeps the old triage-everything behaviour rather than erroring.
+  if ! declare -F process_duplicate_conflicts >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local quarantine_dir="${TR_TORRENT_DIR%/*}/triage/quarantine"
+
+  local replaced
+  replaced="$(process_duplicate_conflicts "${filebot_output}" "${quarantine_dir}" 2>/dev/null)"
+  [[ "${replaced}" =~ ^[0-9]+$ ]] || return 0
+  [[ "${replaced}" -gt 0 ]] || return 0
+
+  # replace_media_file returns success in dry run without moving anything, so
+  # `replaced` counts what WOULD have happened. Acting on it here would make a
+  # dry run issue a real Plex scan and really delete quarantined files, which
+  # is the one thing dry run promises not to do.
+  if [[ "${MEDIA_COMPARE_DRY_RUN:-false}" == "true" ]]; then
+    log "DRY RUN: would upgrade ${replaced} library file(s) and rescan Plex"
+    return 0
+  fi
+
+  log "Upgraded ${replaced} library file(s) with higher-quality copies"
+
+  # Only scan when something actually changed — this runs on every duplicate,
+  # and a scan with nothing to find is wasted work on a large library.
+  local detected_type="movie"
+  if echo "${filebot_output}" | grep -iq "TV Shows"; then
+    detected_type="show"
+  fi
+  trigger_plex_scan "${detected_type}" || log "Warning: Plex scan after upgrade failed"
+
+  prune_quarantine "${quarantine_dir}" || true
+  return 0
 }
 
 # Move a failed torrent to a triage directory based on failure category.

--- a/docs/apps/transmission-filebot-README.md
+++ b/docs/apps/transmission-filebot-README.md
@@ -110,6 +110,69 @@ Cleanup empty directories
 - **Pattern-based media type detection**: Filename analysis before attempting FileBot processing
 - **stdout/stderr separation**: All user messages to stderr, only data to stdout
 
+### Duplicate handling and quality upgrades
+
+FileBot runs with `--conflict auto`, which **skips** rather than overwrites when
+a download renames onto a path that already holds a file. The download is then
+classified `already-in-plex` by `classify_failure()` and moved to
+`triage/already-in-plex/`. Nothing is overwritten and nothing is lost.
+
+`media-compare.sh` decides which of the two copies is better, so that the
+download is not left sitting in triage waiting for someone to compare them by
+hand (issue #178). It is a sourced library, like `pia-port-guard.sh`, and is
+optional: when the file is absent, `transmission-done.sh` keeps its previous
+behaviour of triaging every duplicate.
+
+**Pairing.** The download and the library file it collides with are read from
+FileBot's own conflict message, which names both paths:
+
+```text
+[AUTO] Skipped [SOURCE] because [DEST] already exists
+[IMPORT] Destination file already exists: DEST (SOURCE)
+```
+
+FileBot has already matched the download to a title and worked out the exact
+destination, so taking the pair from its output is authoritative. Guessing it
+back from filenames is not. Anything unparsable yields no pair, and the
+download goes to triage as before.
+
+**Comparison ladder.** `ffprobe` (from the `ffmpeg` formula, already in
+`config/formulae.txt`) reads the attributes. The first rule that separates the
+two files decides:
+
+1. Identical bytes → keep (a size check first, then `cmp`)
+2. Video resolution, as width × height → more pixels wins
+3. Video bitrate → higher wins, past a 10% noise margin
+4. Audio channels → more wins
+5. File size → larger wins, as a last resort only
+
+**Everything uncertain resolves to keep.** A wrong "replace" destroys the better
+copy; a wrong "keep" costs disk space and a triage entry. Those are not
+symmetric, so an unreadable file, a probe timeout, or a tie on every rule all
+leave the library alone.
+
+**Replacement** is ordered so the library is never short an episode: the
+incumbent moves to `triage/quarantine/` first, then the candidate moves into its
+place, and a failure of the second move restores the first. Quarantined files
+are pruned after `MEDIA_COMPARE_RETENTION_DAYS` (default 14).
+
+A Plex rescan fires only when something was actually replaced — this code runs
+on every duplicate, and a scan with nothing to find is wasted work.
+
+**Configuration** (environment variables, all with working defaults):
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MEDIA_COMPARE_DRY_RUN` | `false` | Log decisions, change nothing |
+| `MEDIA_COMPARE_RETENTION_DAYS` | `14` | Quarantine lifetime |
+| `MEDIA_COMPARE_BITRATE_MARGIN` | `10` | Percent difference before bitrate decides |
+| `MEDIA_COMPARE_TIMEOUT` | `30` | Seconds before an ffprobe read is abandoned |
+| `MEDIA_COMPARE_FFPROBE` | `${HOMEBREW_PREFIX}/bin/ffprobe` | Probe binary |
+
+Tests live in `tests/media-compare.bats` and probe real media synthesised by
+`ffmpeg` rather than mocking `ffprobe`, so a wrong `-show_entries` spec or a
+misread field name fails the suite instead of passing it.
+
 ### Critical Environment Variables
 
 When Transmission invokes the script, it provides:

--- a/tests/media-compare.bats
+++ b/tests/media-compare.bats
@@ -1,0 +1,744 @@
+#!/usr/bin/env bats
+#
+# Tests for media-compare.sh — deciding which copy of a duplicate to keep.
+#
+# These tests probe real media files rather than mocking ffprobe. Mocking would
+# only prove the comparison ladder handles strings this file invented; it would
+# never catch a wrong -show_entries spec or a misread field name, which is
+# exactly the class of mistake most likely here. ffmpeg synthesises the
+# fixtures in about a tenth of a second each, so the cost is small and the
+# tests exercise the real ffprobe invocation end to end.
+#
+# The asymmetry the library is built around: a wrong "replace" destroys the
+# better copy, while a wrong "keep" costs disk space and a triage entry. Every
+# uncertain case must therefore resolve to keep, and several tests below exist
+# only to pin that direction.
+#
+# Run with: bats tests/media-compare.bats
+
+BATS_TEST_FILENAME="${BATS_TEST_FILENAME:-}"
+REPO_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+LIBRARY="${REPO_DIR}/app-setup/templates/media-compare.sh"
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  export TEST_TMPDIR
+
+  if ! command -v ffmpeg >/dev/null 2>&1; then
+    skip "ffmpeg not installed (config/formulae.txt ships it on the server)"
+  fi
+
+  # shellcheck source=/dev/null
+  source "${LIBRARY}"
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+}
+
+# ---------------------------------------------------------------------------
+# Fixture generation
+#
+# One second of test pattern plus a tone. Arguments are chosen so each rule in
+# the ladder can be isolated: vary only resolution, or only bitrate, or only
+# channel count, and every other attribute stays comparable.
+# ---------------------------------------------------------------------------
+make_media() {
+  local name="$1" size="$2" bitrate="$3" channels="$4"
+  local path="${TEST_TMPDIR}/${name}"
+  ffmpeg -y -v error \
+    -f lavfi -i "testsrc=size=${size}:rate=10:duration=1" \
+    -f lavfi -i "sine=frequency=440:duration=1" \
+    -c:v libx264 -b:v "${bitrate}" \
+    -c:a aac -ac "${channels}" \
+    "${path}" 2>/dev/null
+  printf '%s' "${path}"
+}
+
+# First line of compare_media is the verdict, second is the reason.
+verdict() {
+  compare_media "$1" "$2" | head -1
+}
+
+reason() {
+  compare_media "$1" "$2" | sed -n '2p'
+}
+
+# ---------------------------------------------------------------------------
+# Attribute extraction
+# ---------------------------------------------------------------------------
+
+@test "media_resolution reports pixel area, not just height" {
+  local f
+  f="$(make_media "a.mp4" "640x360" "200k" 2)"
+  run media_resolution "${f}"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq $((640 * 360)) ]
+}
+
+@test "media_audio_channels reads the channel count" {
+  local f
+  f="$(make_media "a.mp4" "640x360" "200k" 6)"
+  run media_audio_channels "${f}"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 6 ]
+}
+
+@test "media_video_bitrate returns a positive number" {
+  local f
+  f="$(make_media "a.mp4" "640x360" "200k" 2)"
+  run media_video_bitrate "${f}"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "attribute readers fail rather than print junk for a missing file" {
+  run media_resolution "${TEST_TMPDIR}/nope.mp4"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "attribute readers fail rather than print junk for a non-media file" {
+  # A text file with a video extension is a real case: a failed download, or a
+  # rename that landed on something that was never media.
+  echo "this is not media" >"${TEST_TMPDIR}/fake.mp4"
+  run media_resolution "${TEST_TMPDIR}/fake.mp4"
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Rule 1: identical files
+# ---------------------------------------------------------------------------
+
+@test "a byte-identical copy is kept, not replaced" {
+  local a
+  a="$(make_media "a.mp4" "640x360" "200k" 2)"
+  cp "${a}" "${TEST_TMPDIR}/b.mp4"
+
+  [ "$(verdict "${a}" "${TEST_TMPDIR}/b.mp4")" = "keep" ]
+  [[ "$(reason "${a}" "${TEST_TMPDIR}/b.mp4")" == *"identical"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Rule 2: resolution
+# ---------------------------------------------------------------------------
+
+@test "a higher-resolution download replaces the library copy" {
+  local hd sd
+  hd="$(make_media "hd.mp4" "1920x1080" "2000k" 2)"
+  sd="$(make_media "sd.mp4" "640x360" "2000k" 2)"
+
+  [ "$(verdict "${hd}" "${sd}")" = "replace" ]
+  [[ "$(reason "${hd}" "${sd}")" == *"resolution"* ]]
+}
+
+@test "a lower-resolution download is kept out of the library" {
+  # The failure this guards against: a 480p re-encode displacing a 1080p copy
+  # because it happened to arrive later.
+  local hd sd
+  hd="$(make_media "hd.mp4" "1920x1080" "2000k" 2)"
+  sd="$(make_media "sd.mp4" "640x360" "2000k" 2)"
+
+  [ "$(verdict "${sd}" "${hd}")" = "keep" ]
+}
+
+@test "resolution outranks size" {
+  # A big low-resolution file must not win on bulk alone. Size is rule 5 and
+  # only applies once the quality rules find nothing.
+  local hd sd
+  hd="$(make_media "hd.mp4" "1280x720" "100k" 2)"
+  sd="$(make_media "sd.mp4" "320x180" "4000k" 2)"
+
+  [ "$(verdict "${sd}" "${hd}")" = "keep" ]
+  [[ "$(reason "${sd}" "${hd}")" == *"resolution"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Rule 3: video bitrate
+# ---------------------------------------------------------------------------
+
+@test "at equal resolution, a much higher bitrate wins" {
+  local high low
+  high="$(make_media "high.mp4" "640x360" "3000k" 2)"
+  low="$(make_media "low.mp4" "640x360" "80k" 2)"
+
+  [ "$(verdict "${high}" "${low}")" = "replace" ]
+  [[ "$(reason "${high}" "${low}")" == *"bitrate"* ]]
+}
+
+@test "at equal resolution, a much lower bitrate loses" {
+  local high low
+  high="$(make_media "high.mp4" "640x360" "3000k" 2)"
+  low="$(make_media "low.mp4" "640x360" "80k" 2)"
+
+  [ "$(verdict "${low}" "${high}")" = "keep" ]
+}
+
+# ---------------------------------------------------------------------------
+# Rule 4: audio channels
+# ---------------------------------------------------------------------------
+
+@test "more audio channels wins when video is comparable" {
+  local surround stereo
+  surround="$(make_media "surround.mp4" "640x360" "200k" 6)"
+  stereo="$(make_media "stereo.mp4" "640x360" "200k" 2)"
+
+  # Both encodes come from the same source at the same settings, so the video
+  # rules tie and the decision falls through to audio.
+  [ "$(verdict "${surround}" "${stereo}")" = "replace" ]
+  [[ "$(reason "${surround}" "${stereo}")" == *"audio channels"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Safety: uncertainty resolves to keep
+# ---------------------------------------------------------------------------
+
+@test "an unreadable candidate never displaces the library copy" {
+  local inc
+  inc="$(make_media "inc.mp4" "640x360" "200k" 2)"
+  echo "truncated garbage" >"${TEST_TMPDIR}/bad.mp4"
+
+  # Nothing about the candidate is measurable except its size, which is tiny.
+  [ "$(verdict "${TEST_TMPDIR}/bad.mp4" "${inc}")" = "keep" ]
+}
+
+@test "a missing candidate is kept, not replaced" {
+  local inc
+  inc="$(make_media "inc.mp4" "640x360" "200k" 2)"
+  [ "$(verdict "${TEST_TMPDIR}/absent.mp4" "${inc}")" = "keep" ]
+}
+
+@test "a missing incumbent still returns keep rather than claiming an upgrade" {
+  local cand
+  cand="$(make_media "cand.mp4" "640x360" "200k" 2)"
+  [ "$(verdict "${cand}" "${TEST_TMPDIR}/absent.mp4")" = "keep" ]
+}
+
+@test "compare_media always prints a verdict and a reason" {
+  local a b
+  a="$(make_media "a.mp4" "640x360" "200k" 2)"
+  b="$(make_media "b.mp4" "640x360" "200k" 2)"
+
+  run compare_media "${a}" "${b}"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 2 ]
+  [[ "$(echo "$output" | head -1)" =~ ^(keep|replace)$ ]]
+  [ -n "$(echo "$output" | sed -n '2p')" ]
+}
+
+@test "compare_media never emits a verdict other than keep or replace" {
+  # Sweep the shapes a caller can actually hit, including the degenerate ones.
+  local good
+  good="$(make_media "good.mp4" "640x360" "200k" 2)"
+  echo "junk" >"${TEST_TMPDIR}/junk.mp4"
+  : >"${TEST_TMPDIR}/empty.mp4"
+
+  local candidates=("${good}" "${TEST_TMPDIR}/junk.mp4" "${TEST_TMPDIR}/empty.mp4" "${TEST_TMPDIR}/absent.mp4")
+  local c i
+  for c in "${candidates[@]}"; do
+    for i in "${candidates[@]}"; do
+      local v
+      v="$(compare_media "${c}" "${i}" | head -1)"
+      [[ "${v}" =~ ^(keep|replace)$ ]] || {
+        echo "unexpected verdict '${v}' for candidate=${c} incumbent=${i}" >&2
+        return 1
+      }
+    done
+  done
+}
+
+# ---------------------------------------------------------------------------
+# replace_media_file
+# ---------------------------------------------------------------------------
+
+@test "replace moves the incumbent to quarantine and installs the candidate" {
+  local cand inc
+  cand="$(make_media "cand.mp4" "1920x1080" "2000k" 2)"
+  inc="$(make_media "inc.mp4" "640x360" "200k" 2)"
+  local cand_sum
+  cand_sum="$(shasum "${cand}" | awk '{print $1}')"
+
+  run replace_media_file "${cand}" "${inc}" "${TEST_TMPDIR}/quarantine"
+  [ "$status" -eq 0 ]
+
+  # The library slot now holds what used to be the candidate...
+  [ -f "${inc}" ]
+  [ "$(shasum "${inc}" | awk '{print $1}')" = "${cand_sum}" ]
+
+  # ...the candidate has been consumed, not copied...
+  [ ! -f "${cand}" ]
+
+  # ...and the displaced copy is recoverable.
+  [ "$(find "${TEST_TMPDIR}/quarantine" -type f | wc -l | tr -d ' ')" -eq 1 ]
+}
+
+@test "dry run reports the replacement without touching either file" {
+  local cand inc
+  cand="$(make_media "cand.mp4" "1920x1080" "2000k" 2)"
+  inc="$(make_media "inc.mp4" "640x360" "200k" 2)"
+  local inc_sum
+  inc_sum="$(shasum "${inc}" | awk '{print $1}')"
+
+  MEDIA_COMPARE_DRY_RUN=true run replace_media_file "${cand}" "${inc}" "${TEST_TMPDIR}/quarantine"
+  [ "$status" -eq 0 ]
+
+  [ -f "${cand}" ]
+  [ "$(shasum "${inc}" | awk '{print $1}')" = "${inc_sum}" ]
+  [ ! -d "${TEST_TMPDIR}/quarantine" ]
+}
+
+@test "replace refuses when the candidate is missing" {
+  local inc
+  inc="$(make_media "inc.mp4" "640x360" "200k" 2)"
+  run replace_media_file "${TEST_TMPDIR}/absent.mp4" "${inc}" "${TEST_TMPDIR}/quarantine"
+  [ "$status" -ne 0 ]
+  [ -f "${inc}" ]
+}
+
+@test "a failed install restores the incumbent rather than leaving a hole" {
+  # The library must never end up short an episode.
+  #
+  # Reaching the restore path needs the first mv (incumbent -> quarantine) to
+  # succeed and the second (candidate -> library) to fail. Making the library
+  # directory read-only does NOT do that: the incumbent lives there too, so the
+  # quarantine move fails first and the function aborts before it can restore
+  # anything. An earlier version of this test did exactly that and passed
+  # against code with the restore path deleted.
+  #
+  # So make the *candidate's* directory read-only instead. Moving a file out of
+  # a read-only directory fails, while the library and quarantine stay writable.
+  local libdir canddir inc cand
+  libdir="${TEST_TMPDIR}/library"
+  canddir="${TEST_TMPDIR}/canddir"
+  mkdir -p "${libdir}" "${canddir}"
+
+  inc="${libdir}/inc.mp4"
+  cp "$(make_media "src.mp4" "640x360" "200k" 2)" "${inc}"
+  cand="${canddir}/cand.mp4"
+  cp "$(make_media "big.mp4" "1920x1080" "2000k" 2)" "${cand}"
+
+  local inc_sum
+  inc_sum="$(shasum "${inc}" | awk '{print $1}')"
+
+  chmod 500 "${canddir}"
+  run replace_media_file "${cand}" "${inc}" "${TEST_TMPDIR}/quarantine"
+  chmod 700 "${canddir}"
+
+  [ "$status" -ne 0 ]
+
+  # The library slot still holds the original, byte for byte...
+  [ -f "${inc}" ]
+  [ "$(shasum "${inc}" | awk '{print $1}')" = "${inc_sum}" ]
+
+  # ...and nothing was stranded in quarantine.
+  [ "$(find "${TEST_TMPDIR}/quarantine" -type f 2>/dev/null | wc -l | tr -d ' ')" -eq 0 ]
+
+  # Prove the restore path actually ran, rather than the function bailing out
+  # before the first move -- which is how the earlier version of this test
+  # passed against code with no restore path at all.
+  [[ "$output" == *"restoring"* ]]
+  [[ "$output" == *"library is unchanged"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# prune_quarantine
+# ---------------------------------------------------------------------------
+
+@test "prune removes files past the retention window" {
+  local q="${TEST_TMPDIR}/quarantine"
+  mkdir -p "${q}"
+  touch "${q}/old.mp4" "${q}/new.mp4"
+  # -mtime +14 needs an mtime strictly older than 15 days.
+  touch -t "$(date -v-20d '+%Y%m%d%H%M')" "${q}/old.mp4"
+
+  run prune_quarantine "${q}" 14
+  [ "$status" -eq 0 ]
+  [ ! -f "${q}/old.mp4" ]
+  [ -f "${q}/new.mp4" ]
+}
+
+@test "prune leaves everything alone in dry run" {
+  local q="${TEST_TMPDIR}/quarantine"
+  mkdir -p "${q}"
+  touch "${q}/old.mp4"
+  touch -t "$(date -v-20d '+%Y%m%d%H%M')" "${q}/old.mp4"
+
+  MEDIA_COMPARE_DRY_RUN=true run prune_quarantine "${q}" 14
+  [ "$status" -eq 0 ]
+  [ -f "${q}/old.mp4" ]
+}
+
+@test "prune on a missing directory is a no-op, not an error" {
+  run prune_quarantine "${TEST_TMPDIR}/never-existed" 14
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# parse_filebot_conflicts
+#
+# The pairing comes from FileBot's own conflict message, which names both the
+# download and the library path it collides with. Guessing that pairing back
+# from filenames would be far less reliable than reading what FileBot decided.
+# ---------------------------------------------------------------------------
+
+@test "parses the AUTO Skipped conflict format" {
+  local out
+  out="$(parse_filebot_conflicts '[AUTO] Skipped [/src/video.mkv] because [/dst/video.mkv] already exists
+Processed 0 files')"
+  [ "${out}" = "$(printf '/src/video.mkv\t/dst/video.mkv')" ]
+}
+
+@test "parses the IMPORT destination-exists format, which lists the paths in the other order" {
+  local out
+  out="$(parse_filebot_conflicts '[IMPORT] Destination file already exists: /dst/video.mkv (/src/video.mkv)
+Processed 0 files')"
+  # source first, destination second -- same shape as the AUTO format above,
+  # even though FileBot prints them the other way round.
+  [ "${out}" = "$(printf '/src/video.mkv\t/dst/video.mkv')" ]
+}
+
+@test "parses several conflicts from one run" {
+  local out
+  out="$(parse_filebot_conflicts '[AUTO] Skipped [/src/ep1.mkv] because [/dst/ep1.mkv] already exists
+[AUTO] Skipped [/src/ep2.mkv] because [/dst/ep2.mkv] already exists
+Processed 0 files')"
+  [ "$(echo "${out}" | wc -l | tr -d ' ')" -eq 2 ]
+}
+
+@test "keeps paths containing spaces intact" {
+  # Release names routinely contain spaces; splitting on them would pair the
+  # wrong files together.
+  local out
+  out="$(parse_filebot_conflicts '[AUTO] Skipped [/src/The Movie (2024).mkv] because [/dst/The Movie (2024).mkv] already exists')"
+  [ "${out}" = "$(printf '/src/The Movie (2024).mkv\t/dst/The Movie (2024).mkv')" ]
+}
+
+@test "output with no conflict yields no pairs" {
+  local out
+  out="$(parse_filebot_conflicts 'Rename episodes using [TheMovieDB]
+Processed 3 files')"
+  [ -z "${out}" ]
+}
+
+# ---------------------------------------------------------------------------
+# process_duplicate_conflicts
+# ---------------------------------------------------------------------------
+
+@test "a better download replaces the library copy and is counted" {
+  local libdir="${TEST_TMPDIR}/library"
+  mkdir -p "${libdir}"
+  local inc="${libdir}/show.mp4"
+  cp "$(make_media "sd.mp4" "640x360" "200k" 2)" "${inc}"
+  local cand
+  cand="$(make_media "hd.mp4" "1920x1080" "2000k" 2)"
+
+  # Capture stdout only. media_compare_log writes to stderr, and BATS's `run`
+  # merges the two streams -- which would bury the count this function returns.
+  local replaced
+  replaced="$(process_duplicate_conflicts \
+    "[AUTO] Skipped [${cand}] because [${inc}] already exists" \
+    "${TEST_TMPDIR}/quarantine" 2>/dev/null)"
+
+  [ "${replaced}" -eq 1 ]
+  # The library slot now holds the HD copy.
+  [ "$(media_resolution "${inc}")" -eq $((1920 * 1080)) ]
+}
+
+@test "a worse download leaves the library alone and counts nothing" {
+  local libdir="${TEST_TMPDIR}/library"
+  mkdir -p "${libdir}"
+  local inc="${libdir}/show.mp4"
+  cp "$(make_media "hd.mp4" "1920x1080" "2000k" 2)" "${inc}"
+  local cand
+  cand="$(make_media "sd.mp4" "640x360" "200k" 2)"
+
+  local replaced
+  replaced="$(process_duplicate_conflicts \
+    "[AUTO] Skipped [${cand}] because [${inc}] already exists" \
+    "${TEST_TMPDIR}/quarantine" 2>/dev/null)"
+
+  [ "${replaced}" -eq 0 ]
+  [ "$(media_resolution "${inc}")" -eq $((1920 * 1080)) ]
+  # The download is still there for triage to move.
+  [ -f "${cand}" ]
+}
+
+@test "output with no conflicts replaces nothing" {
+  local replaced
+  replaced="$(process_duplicate_conflicts "Processed 3 files" "${TEST_TMPDIR}/quarantine" 2>/dev/null)"
+  [ "${replaced}" -eq 0 ]
+}
+
+@test "dry run counts no replacements and moves no files" {
+  local libdir="${TEST_TMPDIR}/library"
+  mkdir -p "${libdir}"
+  local inc="${libdir}/show.mp4"
+  cp "$(make_media "sd.mp4" "640x360" "200k" 2)" "${inc}"
+  local inc_sum
+  inc_sum="$(shasum "${inc}" | awk '{print $1}')"
+  local cand
+  cand="$(make_media "hd.mp4" "1920x1080" "2000k" 2)"
+
+  MEDIA_COMPARE_DRY_RUN=true process_duplicate_conflicts \
+    "[AUTO] Skipped [${cand}] because [${inc}] already exists" \
+    "${TEST_TMPDIR}/quarantine" >/dev/null 2>&1
+
+  # replace_media_file returns 0 in dry run, so the count reflects what WOULD
+  # have happened -- but nothing on disk may have changed.
+  [ "$(shasum "${inc}" | awk '{print $1}')" = "${inc_sum}" ]
+  [ -f "${cand}" ]
+}
+
+@test "one unreadable pair does not stop the others from being worked" {
+  local libdir="${TEST_TMPDIR}/library"
+  mkdir -p "${libdir}"
+  local inc="${libdir}/good.mp4"
+  cp "$(make_media "sd.mp4" "640x360" "200k" 2)" "${inc}"
+  local cand
+  cand="$(make_media "hd.mp4" "1920x1080" "2000k" 2)"
+
+  local replaced
+  replaced="$(process_duplicate_conflicts \
+    "[AUTO] Skipped [${TEST_TMPDIR}/absent.mp4] because [${TEST_TMPDIR}/also-absent.mp4] already exists
+[AUTO] Skipped [${cand}] because [${inc}] already exists" \
+    "${TEST_TMPDIR}/quarantine" 2>/dev/null)"
+
+  [ "${replaced}" -eq 1 ]
+}
+
+@test "the replacement count is the only thing on stdout" {
+  # Callers capture this with $(...), so a stray log line on stdout would be
+  # concatenated onto the number and break arithmetic at the call site.
+  # media_compare_log must stay on stderr for that to hold.
+  local libdir="${TEST_TMPDIR}/library"
+  mkdir -p "${libdir}"
+  local inc="${libdir}/show.mp4"
+  cp "$(make_media "sd.mp4" "640x360" "200k" 2)" "${inc}"
+  local cand
+  cand="$(make_media "hd.mp4" "1920x1080" "2000k" 2)"
+
+  local replaced
+  replaced="$(process_duplicate_conflicts \
+    "[AUTO] Skipped [${cand}] because [${inc}] already exists" \
+    "${TEST_TMPDIR}/quarantine" 2>/dev/null)"
+
+  # Exactly an integer, with nothing else attached.
+  [[ "${replaced}" =~ ^[0-9]+$ ]]
+}
+
+# ---------------------------------------------------------------------------
+# Integration with transmission-done.sh
+#
+# handle_duplicate_upgrades is defined in transmission-done.sh, which cannot be
+# sourced here (it resolves config, HOME and Plex credentials at load time).
+# Extract just that function and run it against stubs, so the wiring between
+# the pipeline and this library is covered rather than assumed.
+# ---------------------------------------------------------------------------
+
+load_upgrade_handler() {
+  local pipeline="${REPO_DIR}/app-setup/templates/transmission-done.sh"
+
+  # Slicing the file with awk means guessing where the function ends, and every
+  # cheap guess ("the next } at column 0") breaks the day someone adds a
+  # heredoc or a block closed in column 0: the extract comes back truncated and
+  # these tests pass against a function that is not the real one. Ask bash for
+  # the definition instead -- it has already parsed the file, so it knows the
+  # real boundaries.
+  #
+  # transmission-done.sh cannot simply be sourced here: it resolves config,
+  # HOME and Plex credentials at load time. TEST_RUNNER=true stops main() from
+  # running, and the stderr/exit-status noise from the parts that still fail is
+  # discarded -- all this needs is the function text.
+  local body
+  body="$(TEST_RUNNER=true TEST_MODE=true bash -c \
+    'source "$1" >/dev/null 2>&1; declare -f handle_duplicate_upgrades' _ "${pipeline}")"
+
+  # Guard the guard: an empty body would make every assertion below vacuous.
+  [ -n "${body}" ]
+  eval "${body}"
+}
+
+# Stubs for what transmission-done.sh provides at runtime.
+setup_pipeline_stubs() {
+  export TR_TORRENT_DIR="${TEST_TMPDIR}/downloads/pending-move"
+  mkdir -p "${TR_TORRENT_DIR}" "${TEST_TMPDIR}/library"
+  PIPELINE_LOG="${TEST_TMPDIR}/pipeline.log"
+  : >"${PIPELINE_LOG}"
+  # media_compare_log delegates to log() when it exists, which is how decisions
+  # reach the processing log in production.
+  log() { printf '%s\n' "$1" >>"${PIPELINE_LOG}"; }
+  trigger_plex_scan() {
+    printf 'PLEX SCAN: %s\n' "$1" >>"${PIPELINE_LOG}"
+    return 0
+  }
+  load_upgrade_handler
+}
+
+@test "the pipeline upgrades a duplicate and rescans the right Plex library" {
+  setup_pipeline_stubs
+
+  local inc="${TEST_TMPDIR}/library/Show.S01E01.mp4"
+  cp "$(make_media "sd.mp4" "640x360" "200k" 2)" "${inc}"
+  local cand="${TR_TORRENT_DIR}/Show.S01E01.mp4"
+  cp "$(make_media "hd.mp4" "1920x1080" "2000k" 6)" "${cand}"
+
+  handle_duplicate_upgrades "already-in-plex" \
+    "[AUTO] Skipped [${cand}] because [${inc}] already exists
+Rename episodes using [TheTVDB] to TV Shows
+Processed 0 files"
+
+  # The library holds the better copy...
+  [ "$(media_resolution "${inc}")" -eq $((1920 * 1080)) ]
+  # ...the displaced copy is recoverable...
+  [ "$(find "${TEST_TMPDIR}/downloads/triage/quarantine" -type f | wc -l | tr -d ' ')" -eq 1 ]
+  # ...and Plex was told to rescan TV, not movies.
+  grep -q "PLEX SCAN: show" "${PIPELINE_LOG}"
+}
+
+@test "the pipeline scans the movie library for a movie upgrade" {
+  setup_pipeline_stubs
+
+  local inc="${TEST_TMPDIR}/library/Movie.mp4"
+  cp "$(make_media "sd.mp4" "640x360" "200k" 2)" "${inc}"
+  local cand="${TR_TORRENT_DIR}/Movie.mp4"
+  cp "$(make_media "hd.mp4" "1920x1080" "2000k" 2)" "${cand}"
+
+  handle_duplicate_upgrades "already-in-plex" \
+    "[AUTO] Skipped [${cand}] because [${inc}] already exists
+Rename movies using [TheMovieDB]
+Processed 0 files"
+
+  grep -q "PLEX SCAN: movie" "${PIPELINE_LOG}"
+}
+
+@test "the pipeline does not rescan when nothing was upgraded" {
+  # This runs on every duplicate. A scan with nothing to find is wasted work on
+  # a large library, so it must be conditional on an actual replacement.
+  setup_pipeline_stubs
+
+  local inc="${TEST_TMPDIR}/library/Show.S01E01.mp4"
+  cp "$(make_media "hd.mp4" "1920x1080" "2000k" 2)" "${inc}"
+  local cand="${TR_TORRENT_DIR}/Show.S01E01.mp4"
+  cp "$(make_media "sd.mp4" "640x360" "200k" 2)" "${cand}"
+
+  handle_duplicate_upgrades "already-in-plex" \
+    "[AUTO] Skipped [${cand}] because [${inc}] already exists
+Processed 0 files"
+
+  # `run grep`, not `! grep`: POSIX exempts a !-negated command from `set -e`,
+  # so a bare `! grep ...` can never fail a BATS test -- it is a no-op that
+  # reads like an assertion. Checking $status explicitly does abort.
+  run grep -q "PLEX SCAN" "${PIPELINE_LOG}"
+  [ "$status" -ne 0 ]
+  # The download stays put for triage to move, exactly as before.
+  [ -f "${cand}" ]
+}
+
+@test "the pipeline ignores failure categories that are not duplicates" {
+  # no-match and failed mean FileBot never identified a library collision, so
+  # there is no pair to compare and nothing may be touched.
+  setup_pipeline_stubs
+
+  local inc="${TEST_TMPDIR}/library/Show.S01E01.mp4"
+  cp "$(make_media "sd.mp4" "640x360" "200k" 2)" "${inc}"
+  local cand="${TR_TORRENT_DIR}/Show.S01E01.mp4"
+  cp "$(make_media "hd.mp4" "1920x1080" "2000k" 2)" "${cand}"
+
+  handle_duplicate_upgrades "no-match" \
+    "[AUTO] Skipped [${cand}] because [${inc}] already exists"
+
+  # Untouched: still the SD copy, and no scan.
+  [ "$(media_resolution "${inc}")" -eq $((640 * 360)) ]
+  [ ! -s "${PIPELINE_LOG}" ]
+}
+
+@test "the pipeline survives the comparison library being absent" {
+  # media-compare.sh is sourced only when present. A deployment without it must
+  # keep the old triage-everything behaviour rather than erroring.
+  setup_pipeline_stubs
+  unset -f process_duplicate_conflicts
+
+  run handle_duplicate_upgrades "already-in-plex" "[AUTO] Skipped [/a] because [/b] already exists"
+  [ "$status" -eq 0 ]
+}
+
+@test "an IMPORT conflict with parentheses in both paths is split correctly" {
+  # `DEST (SOURCE)` cannot be split by pattern once both paths contain " (",
+  # which is routine for films with a year in the name. A greedy regex pairs a
+  # fragment of one path with a fragment of the other, and the library then
+  # quarantines a file nobody asked it to touch. The split is resolved against
+  # the filesystem instead.
+  mkdir -p "${TEST_TMPDIR}/plex" "${TEST_TMPDIR}/dl"
+  local dest="${TEST_TMPDIR}/plex/The Thing (1982).mkv"
+  local src="${TEST_TMPDIR}/dl/The Thing (1982).mkv"
+  : >"${dest}"
+  : >"${src}"
+
+  local out
+  out="$(parse_filebot_conflicts "[IMPORT] Destination file already exists: ${dest} (${src})")"
+  [ "${out}" = "$(printf '%s\t%s' "${src}" "${dest}")" ]
+}
+
+@test "an unsplittable IMPORT conflict never pairs mismatched files" {
+  # When no split validates, whatever comes back must not name two real files
+  # that FileBot did not actually pair -- that is the case that would quarantine
+  # the wrong copy.
+  local out
+  out="$(parse_filebot_conflicts '[IMPORT] Destination file already exists: /gone/a (1).mkv (/gone/b (1).mkv)')"
+  local paired_src="${out%%	*}"
+  local paired_dest="${out##*	}"
+  # Neither half may resolve to a real file, so compare_media refuses the pair.
+  [ ! -f "${paired_src}" ]
+  [ ! -f "${paired_dest}" ]
+}
+
+@test "a dry run neither rescans Plex nor prunes quarantine" {
+  # replace_media_file returns success in dry run without moving anything, so
+  # the count reflects what would have happened. Acting on it would make a dry
+  # run issue a real Plex scan and really delete quarantined files.
+  setup_pipeline_stubs
+
+  local inc="${TEST_TMPDIR}/library/Show.S01E01.mp4"
+  cp "$(make_media "sd.mp4" "640x360" "200k" 2)" "${inc}"
+  local cand="${TR_TORRENT_DIR}/Show.S01E01.mp4"
+  cp "$(make_media "hd.mp4" "1920x1080" "2000k" 2)" "${cand}"
+
+  # A quarantined file well past retention: a real prune would remove it.
+  local q="${TEST_TMPDIR}/downloads/triage/quarantine"
+  mkdir -p "${q}"
+  touch "${q}/old.mp4"
+  touch -t "$(date -v-40d '+%Y%m%d%H%M')" "${q}/old.mp4"
+
+  MEDIA_COMPARE_DRY_RUN=true handle_duplicate_upgrades "already-in-plex" \
+    "[AUTO] Skipped [${cand}] because [${inc}] already exists
+Rename episodes using [TheTVDB] to TV Shows"
+
+  run grep -q "PLEX SCAN" "${PIPELINE_LOG}"
+  [ "$status" -ne 0 ]
+  [ -f "${q}/old.mp4" ]
+  # And the library is untouched.
+  [ "$(media_resolution "${inc}")" -eq $((640 * 360)) ]
+}
+
+@test "the bitrate fallback fires for containers with no per-stream bitrate" {
+  # Matroska routinely reports stream=bit_rate as N/A, which is why
+  # media_video_bitrate falls back to the container's overall rate. MKV is a
+  # common release container, so this path carries real traffic rather than
+  # being a defensive afterthought.
+  local mkv="${TEST_TMPDIR}/a.mkv"
+  ffmpeg -y -v error \
+    -f lavfi -i "testsrc=size=640x360:rate=10:duration=1" \
+    -f lavfi -i "sine=frequency=440:duration=1" \
+    -c:v libx264 -b:v 200k -c:a aac -ac 2 "${mkv}" 2>/dev/null
+
+  # Confirm the premise: the primary probe really does come back unusable here,
+  # so this test would still mean something if ffmpeg's defaults changed.
+  run media_probe_field "${mkv}" "v:0" "stream=bit_rate"
+  [ "$status" -ne 0 ]
+
+  # ...and the fallback supplies a usable number anyway.
+  run media_video_bitrate "${mkv}"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}

--- a/tests/media-compare.bats
+++ b/tests/media-compare.bats
@@ -742,3 +742,41 @@ Rename episodes using [TheTVDB] to TV Shows"
   [ "$status" -eq 0 ]
   [ "$output" -gt 0 ]
 }
+
+@test "an IMPORT conflict whose paths end in a close paren still pairs correctly" {
+  # Only one trailing ")" is stripped before the split points are walked, so a
+  # path that genuinely ends in ")" -- a season or edition folder, say -- looks
+  # like it should lose a character. It does not: the walk keeps whichever
+  # split leaves both halves naming real files, which repairs the strip.
+  mkdir -p "${TEST_TMPDIR}/plex" "${TEST_TMPDIR}/dl"
+  local dest="${TEST_TMPDIR}/plex/Movie (2024)"
+  local src="${TEST_TMPDIR}/dl/Movie (2024)"
+  : >"${dest}"
+  : >"${src}"
+
+  local out
+  out="$(parse_filebot_conflicts "[IMPORT] Destination file already exists: ${dest} (${src})")"
+  [ "${out}" = "$(printf '%s\t%s' "${src}" "${dest}")" ]
+}
+
+@test "two replacements in the same second do not overwrite each other in quarantine" {
+  # An episode pack can replace several like-named files inside one second. A
+  # bare timestamp would make the second quarantined copy overwrite the first,
+  # destroying the file quarantine exists to preserve.
+  local q="${TEST_TMPDIR}/quarantine"
+  local libdir="${TEST_TMPDIR}/library"
+  mkdir -p "${libdir}"
+
+  local i
+  for i in 1 2; do
+    local inc="${libdir}/Show.mp4"
+    cp "$(make_media "sd${i}.mp4" "640x360" "200k" 2)" "${inc}"
+    local cand
+    cand="$(make_media "hd${i}.mp4" "1920x1080" "2000k" 2)"
+    run replace_media_file "${cand}" "${inc}" "${q}"
+    [ "$status" -eq 0 ]
+  done
+
+  # Both displaced copies survive.
+  [ "$(find "${q}" -type f | wc -l | tr -d ' ')" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

Closes #178. When a download duplicates media already in the library, compare
the two objectively, keep the better copy, and rescan Plex.

## What happens today

FileBot runs with `--conflict auto`, which **skips** rather than overwrites. The
download is classified `already-in-plex` and moved to `triage/already-in-plex/`.
So the issue's core worry — that a new file might overwrite an old one without
quality checks — is not what happens: nothing is overwritten and nothing is
lost.

What is missing is the decision. The better copy sits in triage until someone
compares the two by hand. This PR makes that comparison.

## Design

**`media-compare.sh`** is a sourced library, like `pia-port-guard.sh`, and is
optional — when absent, `transmission-done.sh` keeps triaging every duplicate
exactly as before.

**Pairing** comes from FileBot's own conflict message, which names both the
download and the library path it collides with. FileBot has already matched the
title and computed the destination, so reading its output is authoritative
where guessing from filenames is not.

The `[IMPORT] ... DEST (SOURCE)` form is genuinely ambiguous once both paths
contain `" ("`, which is routine for films with a year in the name. A greedy
regex pairs a fragment of one path with a fragment of the other — and
quarantining the wrong library file is the worst thing this code could do. That
split is resolved against the filesystem instead: try each candidate point and
keep the one where both halves are real files.

**Comparison ladder** — `ffprobe` (from `ffmpeg`, already in
`config/formulae.txt`), first rule that separates the files wins:

1. Identical bytes → keep
2. Resolution, as width × height → more pixels wins
3. Video bitrate → higher wins, past a 10% noise margin
4. Audio channels → more wins
5. Size → larger wins, last resort only

Matroska reports no per-stream bitrate, so rule 3 falls back to the container
rate — a path MKV releases take routinely, not a defensive afterthought.

**Everything uncertain resolves to keep.** A wrong "replace" destroys the better
copy; a wrong "keep" costs disk space and a triage entry. Not symmetric, so an
unreadable file, a probe timeout, or a tie on every rule all leave the library
alone.

**Replacement** is ordered so the library is never short an episode: incumbent
to quarantine first, candidate into place second, and a failure of the second
restores the first. Quarantined copies are pruned after
`MEDIA_COMPARE_RETENTION_DAYS` (default 14). A Plex rescan fires only when
something actually changed — this runs on every duplicate, and a scan with
nothing to find is wasted work.

Dry-run mode (`MEDIA_COMPARE_DRY_RUN=true`) logs decisions and touches nothing,
including no Plex scan and no prune.

## Verification

46 new tests, **342 assertions total**, `shellcheck -S info` and `shfmt` clean.

Tests probe **real media synthesised by ffmpeg** rather than mocking `ffprobe`,
so a wrong `-show_entries` spec or a misread field name fails the suite instead
of passing it.

Every assertion was checked against deliberately broken code before being kept.
Three passed against sabotaged code and were rewritten:

- The restore-on-failure test made the library directory read-only — which
  makes the *first* move fail, so the function aborted before the restore path
  ran. It passed against code with that path deleted.
- An assertion written as `! grep ...` **can never fail a BATS test**: POSIX
  exempts a `!`-negated command from `set -e`. Rewritten as `run grep` plus an
  explicit status check.
- The function-extraction helper sliced `transmission-done.sh` with `awk`, which
  guesses where a function ends. It asks bash via `declare -f` now.

Two real bugs the dry-run pre-push review caught, both fixed with tests that
fail without the fix:

- A dry run issued a real Plex scan and really pruned quarantine.
- The greedy IMPORT regex described above.

One more from the local reviewer, also fixed and falsified: two replacements
inside the same second overwrote each other in quarantine.

## Note for a follow-up

Five more `! grep` assertions exist in `tests/pia-port-guard.bats` and
`tests/transmission-post-start.bats`. Each is currently backed by a real
assertion in the same test, so **none is hiding a live bug** — verified by
sabotaging `is_valid_port` and confirming those tests still fail on their other
assertions. Left for a separate change rather than widening this one.

https://claude.ai/code/session_015pHBKtjHYArgVfUtC74m6x
