### PR TITLE
test(pia): make the "never called -p" assertions able to fail

### DIFF
--- a/tests/pia-port-guard.bats
+++ b/tests/pia-port-guard.bats
@@ -109,6 +109,14 @@ teardown() {
 }
 
 # --- apply_port ------------------------------------------------------------
+#
+# Assertions that something did NOT happen are written as `run grep` plus an
+# explicit status check, never as a bare `! grep ...`. POSIX exempts a
+# !-negated command from `set -e`, so `! grep -q ...` cannot fail a BATS test:
+# it reads like an assertion and behaves like a no-op. These tests exist to
+# prove that an invalid port never reaches `transmission-remote -p`, which is
+# the failure that stopped downloads for 47 hours -- an assertion that cannot
+# fail is worse than none, because it looks like coverage.
 
 @test "apply_port sets a valid port that differs from the current one" {
   export STUB_CURRENT_PORT="33361"
@@ -122,7 +130,8 @@ teardown() {
   run apply_port 54321 "http://localhost:9091/transmission/rpc"
   [ "$status" -eq 0 ]
   [[ "$output" == *"no change needed"* ]]
-  ! grep -q -- "-p 54321" "${CALL_LOG}"
+  run grep -q -- "-p 54321" "${CALL_LOG}"
+  [ "$status" -ne 0 ]
 }
 
 @test "apply_port refuses an empty port and never calls -p" {
@@ -130,7 +139,8 @@ teardown() {
   run apply_port "" "http://localhost:9091/transmission/rpc"
   [ "$status" -ne 0 ]
   [[ "$output" == *"REFUSING"* ]]
-  ! grep -q -- " -p " "${CALL_LOG}"
+  run grep -q -- " -p " "${CALL_LOG}"
+  [ "$status" -ne 0 ]
 }
 
 @test "apply_port reports the preserved port when refusing" {
@@ -150,7 +160,8 @@ teardown() {
   export STUB_CURRENT_PORT="33361"
   run apply_port "null" "http://localhost:9091/transmission/rpc"
   [ "$status" -ne 0 ]
-  ! grep -q -- " -p " "${CALL_LOG}"
+  run grep -q -- " -p " "${CALL_LOG}"
+  [ "$status" -ne 0 ]
 }
 
 @test "apply_port passes auth arguments through without word splitting" {
@@ -164,7 +175,8 @@ teardown() {
   export STUB_CURRENT_PORT="33361"
   run apply_port 54321 "http://localhost:9091/transmission/rpc"
   [ "$status" -eq 0 ]
-  ! grep -q -- "--auth" "${CALL_LOG}"
+  run grep -q -- "--auth" "${CALL_LOG}"
+  [ "$status" -ne 0 ]
 }
 
 # --- idempotency ------------------------------------------------------------

--- a/tests/transmission-post-start.bats
+++ b/tests/transmission-post-start.bats
@@ -83,7 +83,8 @@ teardown() {
   done
 
   # Nothing above should have reached transmission-remote with -p.
-  ! grep -q -- " -p " "${CALL_LOG}"
+  run grep -q -- " -p " "${CALL_LOG}"
+  [ "$status" -ne 0 ]
 }
 
 @test "the guard applies a well-formed port" {


### PR DESCRIPTION
## Summary

An assertion written as `! grep -q ...` **cannot fail a BATS test**. POSIX
exempts a `!`-negated command from `set -e`, so the line reads like an
assertion and behaves like a no-op:

```bash
bash -c 'set -e; echo x > /tmp/f; ! grep -q x /tmp/f; echo "still here"'
# still here      <- the failed negation did not abort
```

Five of these were sitting on the tests that prove an invalid port never
reaches `transmission-remote -p` — the failure that stopped downloads for 47
hours in August (#181). Rewritten as `run grep` plus an explicit status check,
which does abort.

## Was anything actually broken?

**No live bug.** Every affected test also carried a real assertion, so
sabotaging `is_valid_port` before this change already failed three of them on
those other assertions.

But one test was genuinely vacuous. With `apply_port` rewired to call `-p` for
every invalid port:

| Test | Before | After |
| --- | --- | --- |
| `apply_port refuses an empty port and never calls -p` | **passed** (wrongly) | fails |
| `the guard rejects every port the API could plausibly return as broken` | **passed** (wrongly) | fails |
| `apply_port works with no auth arguments supplied` (injected `--auth`) | **passed** (wrongly) | fails |
| `apply_port reports the preserved port when refusing` | fails | fails |
| `apply_port warns when Transmission is already at port 0` | fails | fails |
| `apply_port refuses jq null without calling -p` | fails | fails |

The three that flipped were relying on the negated grep as their only check of
the claim in their own name.

## Verification

Each converted assertion was checked against deliberately broken code and
confirmed to fail there and pass here. Full suite green; `shfmt` clean.

A comment above the `apply_port` block records why the pattern is banned, so it
does not come back the next time someone writes a negative assertion.

Found while working #178 (#187), where the same mistake made a new test pass
against code with its restore-on-failure path deleted.

https://claude.ai/code/session_015pHBKtjHYArgVfUtC74m6x
