### PR TITLE
style(pia): give maybe_heartbeat one output contract for both branches

### DIFF
--- a/app-setup/templates/pia-port-watchdog.sh
+++ b/app-setup/templates/pia-port-watchdog.sh
@@ -214,7 +214,15 @@ maybe_heartbeat() {
 
   if [[ $((now_epoch - last_epoch)) -ge ${HEARTBEAT_INTERVAL_SECONDS} ]]; then
     log "OK: ${detail}"
-    date -u '+%Y-%m-%dT%H:%M:%SZ'
+    # Assign first, then print through the same printf the suppressed branch
+    # uses, so both return paths have one visible output contract. Command
+    # substitution strips the trailing newline either way, so this changes
+    # nothing a caller can observe -- but a reader no longer has to work that
+    # out to be sure. Assigning separately also keeps date's exit status
+    # visible instead of burying it inside printf's arguments.
+    local now
+    now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf '%s' "${now}"
     return 0
   fi
 


### PR DESCRIPTION
## Summary

Closes #189, the review-findings issue filed during the #186 push.

Two items were in it. **One needs no code**: it records the
`podman-machine-start.bats` fixture correction that already merged in #186,
which the reviewer noted "for completeness". **The other is this change.**

## The change

`maybe_heartbeat` printed its timestamp two different ways depending on which
branch returned:

```bash
date -u '+%Y-%m-%dT%H:%M:%SZ'     # heartbeat fired  — appends a newline
printf '%s' "${current}"           # suppressed       — does not
```

Both are captured with `heartbeat="$(maybe_heartbeat ...)"`, and command
substitution strips trailing newlines, so **nothing a caller can observe
differs**. Verified rather than assumed:

```text
old=[2026-08-26T02:10:56Z] len=20
new=[2026-08-26T02:10:56Z] len=20
```

The asymmetry still costs a reader something — two return paths that look like
they have different output contracts, in a function whose entire job is to
return a value. Assign first, then print through the same `printf`, so the
branches match.

Assigning separately rather than nesting `$(date ...)` inside `printf` also
keeps `date`'s exit status visible instead of masking it. My first attempt did
nest it and tripped SC2312 — trading a cosmetic asymmetry for a lint warning
would have been a bad deal, so this form satisfies both.

## Verification

Full suite green (`tests/pia-port-watchdog.bats` 22/22), `shellcheck -S info`
and `shfmt` clean, dry-run codebase review PASS with no findings.

Behaviour-preserving by construction and by measurement — this is a
readability change, not a bug fix.

https://claude.ai/code/session_015pHBKtjHYArgVfUtC74m6x
